### PR TITLE
Typos, Clarified Comments, Small JDoc/Param Fixes, and Removing Unused Imports

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.common.asm;
 
-import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.common.asm;
 
-import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLCommonLaunchHandler.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLCommonLaunchHandler.java
@@ -158,5 +158,5 @@ public abstract class FMLCommonLaunchHandler
 
     public boolean isData() {
         return false;
-    };
+    }
 }

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -23,14 +23,11 @@ import com.electronwill.nightconfig.core.ConfigSpec;
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.electronwill.nightconfig.core.io.ParsingException;
 import com.electronwill.nightconfig.core.io.WritingMode;
-import net.minecraftforge.api.distmarker.Dist;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import static net.minecraftforge.fml.loading.LogMarkers.CORE;
 

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -203,7 +203,7 @@ public class ModFileInfo implements IModFileInfo, IConfigurable
                     sb.append(" self-signed");
                    } else {
                        sb.append(" signed by ").append(c.getIssuerX500Principal().getName(X500Principal.RFC2253).split(",")[0]);
-                   };
+                   }
                    return sb.toString();
                 });
     }

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.client.event;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -30,7 +29,6 @@ import net.minecraft.client.gui.IGuiEventListener;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraft.client.gui.widget.Widget;
-import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.util.InputMappings;
 

--- a/src/main/java/net/minecraftforge/client/event/ModelBakeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelBakeEvent.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.ModelManager;
-import net.minecraft.client.renderer.model.ModelResourceLocation;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.eventbus.api.Event;

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -30,7 +30,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.ITextProperties;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event;
 
 /**
  * A set of events which are fired at various points during tooltip rendering.

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.client.event.sound;
 
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.client.audio.ISound;
 import net.minecraft.client.audio.SoundEngine;
 import net.minecraft.client.audio.SoundSource;

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeVertexBuilder.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeVertexBuilder.java
@@ -22,7 +22,6 @@ package net.minecraftforge.client.extensions;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.vertex.IVertexBuilder;
 
-import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.util.math.vector.*;

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -23,10 +23,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.client.renderer.model.*;
-import net.minecraft.client.renderer.texture.MissingTextureSprite;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.profiler.IProfiler;

--- a/src/main/java/net/minecraftforge/client/model/PerspectiveMapWrapper.java
+++ b/src/main/java/net/minecraftforge/client/model/PerspectiveMapWrapper.java
@@ -33,7 +33,6 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.vector.TransformationMatrix;
-import net.minecraft.world.World;
 import net.minecraftforge.client.model.data.IDynamicBakedModel;
 import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.common.model.TransformationHelper;

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -498,13 +498,13 @@ public class ModelBlockAnimation
             @SerializedName("origin_y")
             YORIGIN,
             @SerializedName("origin_z")
-            ZORIGIN;
+            ZORIGIN
         }
 
         public static enum Type
         {
             @SerializedName("uniform")
-            UNIFORM;
+            UNIFORM
         }
 
         public static enum Interpolation
@@ -512,7 +512,7 @@ public class ModelBlockAnimation
             @SerializedName("linear")
             LINEAR,
             @SerializedName("nearest")
-            NEAREST;
+            NEAREST
         }
     }
 

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/CompositeModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/CompositeModelBuilder.java
@@ -21,7 +21,6 @@ package net.minecraftforge.client.model.generators.loaders;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
-import net.minecraft.fluid.Fluid;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.generators.CustomLoaderBuilder;
 import net.minecraftforge.client.model.generators.ModelBuilder;

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/SeparatePerspectiveModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/SeparatePerspectiveModelBuilder.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.MultiLayerModel;
 import net.minecraftforge.client.model.SeparatePerspectiveModel;
 import net.minecraftforge.client.model.generators.CustomLoaderBuilder;
 import net.minecraftforge.client.model.generators.ModelBuilder;

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
@@ -31,7 +31,6 @@ import net.minecraftforge.client.model.IModelLoader;
 
 import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.*;
 
 public class OBJLoader implements IModelLoader<OBJModel>

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -395,7 +395,7 @@ public class OBJModel implements IMultipartModelGeometry<OBJModel>
                 normal = norm0.copy();
                 transformation.transformPosition(position);
                 transformation.transformNormal(normal);
-            };
+            }
             Vector4f tintedColor = new Vector4f(
                     color.getX() * colorTint.getX(),
                     color.getY() * colorTint.getY(),

--- a/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
@@ -28,7 +28,6 @@ import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.VoxelShapes;
-import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.IBlockDisplayReader;
 
 public class BlockInfo

--- a/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.InputMappings;
 
 import net.minecraft.util.text.ITextComponent;

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -154,7 +154,7 @@ public class BiomeManager
 
     public static enum BiomeType
     {
-        DESERT, DESERT_LEGACY, WARM, COOL, ICY;
+        DESERT, DESERT_LEGACY, WARM, COOL, ICY
     }
 
     public static class BiomeEntry extends WeightedRandom.Item

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -569,7 +569,7 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfi
             validate(hasComment(), "Non-empty comment when empty expected");
             validate(langKey, "Non-null translation key when null expected");
             validate(range, "Non-null range when null expected");
-            validate(worldRestart, "Dangeling world restart value set to true");
+            validate(worldRestart, "Dangling world restart value set to true");
         }
 
         private void validate(Object value, String message)

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -21,7 +21,6 @@ package net.minecraftforge.common;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.ItemEntity;
-import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.server.ServerWorld;
@@ -38,7 +37,6 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.event.TagsUpdatedEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.TickEvent.ClientTickEvent;
-import net.minecraftforge.event.TickEvent.Phase;
 import net.minecraftforge.event.TickEvent.ServerTickEvent;
 import net.minecraftforge.server.command.ForgeCommand;
 import net.minecraftforge.server.command.ConfigCommand;

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -268,8 +268,15 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         }
     }
 
-    @SubscribeEvent //ModBus, can't use addListener due to nested genetics.
+    // TODO: remove after sufficient time has passed, or 1.17.
+    @Deprecated
     public void registerRecipeSerialziers(RegistryEvent.Register<IRecipeSerializer<?>> event)
+    {
+        registerRecipeSerializers(event);
+    }
+
+    @SubscribeEvent //ModBus, can't use addListener due to nested genetics.
+    public void registerRecipeSerializers(RegistryEvent.Register<IRecipeSerializer<?>> event)
     {
         CraftingHelper.register(AndCondition.Serializer.INSTANCE);
         CraftingHelper.register(FalseCondition.Serializer.INSTANCE);

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -48,7 +48,6 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.server.command.EnumArgument;
 import net.minecraftforge.server.command.ModIdArgument;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import net.minecraftforge.versions.mcp.MCPVersion;
 

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -21,7 +21,6 @@ package net.minecraftforge.common;
 
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraft.crash.CrashReport;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/net/minecraftforge/common/UsernameCache.java
+++ b/src/main/java/net/minecraftforge/common/UsernameCache.java
@@ -66,7 +66,7 @@ public final class UsernameCache {
     private UsernameCache() {}
 
     /**
-     * Set a player's current usernamee
+     * Set a player's current username
      *
      * @param uuid
      *            the player's {@link java.util.UUID UUID}

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -112,9 +112,9 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     @Override
     @Nonnull
-    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side)
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> capability, @Nullable Direction facing)
     {
         final CapabilityDispatcher disp = getCapabilities();
-        return !valid || disp == null ? LazyOptional.empty() : disp.getCapability(cap, side);
+        return !valid || disp == null ? LazyOptional.empty() : disp.getCapability(capability, facing);
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
@@ -38,7 +38,7 @@ public interface ICapabilityProvider
      *   <strong>CAN BE NULL</strong>. Null is defined to represent 'internal' or 'self'
      * @return The requested an optional holding the requested capability.
      */
-    @Nonnull <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side);
+    @Nonnull <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> capability, final @Nullable Direction facing);
 
     /*
      * Purely added as a bouncer to sided version, to make modders stop complaining about calling with a null value.

--- a/src/main/java/net/minecraftforge/common/crafting/IShapedRecipe.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IShapedRecipe.java
@@ -25,7 +25,7 @@ import net.minecraft.item.crafting.IRecipe;
 /**
  * Used to mark a recipe that shape matters so that the recipe
  * book and auto crafting picks the correct shape.
- * Note: These methods can't be named 'getHeight' or 'getWidth' due to obfusication issues.
+ * Note: These methods can't be named 'getHeight' or 'getWidth' due to obfuscation issues.
  */
 public interface IShapedRecipe<T extends IInventory> extends IRecipe<T>
 {

--- a/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
+++ b/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
@@ -100,10 +100,10 @@ public class ExistingFileHelper {
      * <p>
      * Only create a new helper if you intentionally want to ignore the existence of
      * other generated files.
-     *
-     * @param existingPacks
-     * @param existingMods
-     * @param enable
+     * 
+     * @param existingPacks     Collection of existing ResourcePacks to add.
+     * @param existingMods      Set of existing Mods to add.
+     * @param enable            Enables validation; false will set exists() to always return true.
      */
     public ExistingFileHelper(Collection<Path> existingPacks, Set<String> existingMods, boolean enable) {
         this.clientResources = new SimpleReloadableResourceManager(ResourcePackType.CLIENT_RESOURCES);

--- a/src/main/java/net/minecraftforge/common/data/GlobalLootModifierProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/GlobalLootModifierProvider.java
@@ -104,7 +104,7 @@ public abstract class GlobalLootModifierProvider implements IDataProvider
      *
      * @param modifier      The name of the modifier, which will be the file name.
      * @param serializer    The serializer of this modifier.
-     * @param conditions    The loot conditions before {@link LootModifier#doApply} is called.
+     * @param instance      The instance of the modifier to serialize.
      */
     public <T extends IGlobalLootModifier> void add(String modifier, GlobalLootModifierSerializer<T> serializer, T instance)
     {

--- a/src/main/java/net/minecraftforge/common/data/LanguageProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/LanguageProvider.java
@@ -42,7 +42,6 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Effect;
-import net.minecraft.world.biome.Biome;
 
 @SuppressWarnings("deprecation")
 public abstract class LanguageProvider implements IDataProvider {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -440,7 +440,8 @@ public interface IForgeBlockState
     *
     * @param world The world
     * @param pos Block position
-    * @param fortune
+    * @param fortune the level of fortune modifier, or zero if none.
+    * @param silktouch the level of silktouch modifier, or zero if none.
     * @return Amount of XP from breaking this block.
     */
     default int getExpDrop(IWorldReader world, BlockPos pos, int fortune, int silktouch)
@@ -478,7 +479,6 @@ public interface IForgeBlockState
    /**
     * Called on an Observer block whenever an update for an Observer is received.
     *
-    * @param observerState The Observer block's state.
     * @param world The current world.
     * @param pos The Observer block's position.
     * @param changed The updated block.
@@ -532,6 +532,7 @@ public interface IForgeBlockState
     /**
      * Checks if the specified tool type is efficient on this block,
      * meaning that it digs at full speed.
+     * @param tool Type of tool to check against.
      */
     default boolean isToolEffective(ToolType tool)
     {
@@ -551,9 +552,10 @@ public interface IForgeBlockState
     }
 
     /**
+     * Gets the RGB color of a specific beacon's beam.
      * @param world The world
      * @param pos The position of this state
-     * @param beaconPos The position of the beacon
+     * @param beacon The position of the beacon
      * @return A float RGB [0.0, 1.0] array to be averaged with a beacon's existing beam color, or null to do nothing to the beam
      */
     @Nullable
@@ -594,8 +596,9 @@ public interface IForgeBlockState
     }
 
     /**
-     * @param state The state
-     * @return true if the block is sticky block which used for pull or push adjacent blocks (use by piston)
+     * If the block is a Slime Block.
+     *
+     * @return true if the block is slime block which used for pull or push adjacent blocks (use by piston)
      */
     default boolean isSlimeBlock()
     {
@@ -603,7 +606,8 @@ public interface IForgeBlockState
     }
 
     /**
-     * @param state The state
+     * If the block is a Sticky Block, either a Slime Block or honey block.
+     *
      * @return true if the block is sticky block which used for pull or push adjacent blocks (use by piston)
      */
     default boolean isStickyBlock()
@@ -613,6 +617,7 @@ public interface IForgeBlockState
 
     /**
      * Determines if this block can stick to another block when pushed by a piston.
+     *
      * @param other Other block
      * @return True to link blocks
      */
@@ -790,7 +795,7 @@ public interface IForgeBlockState
      * @param pos The block position in world
      * @param player The player clicking the block
      * @param stack The stack being used by the player
-     * @param toolTypes The tool types to be considered when performing the action
+     * @param toolType The tool type to be considered when performing the action
      * @return The resulting state after the action has been performed
      */
     @Nullable

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.LeashKnotEntity;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.item.ArmorStandEntity;
 import net.minecraft.entity.item.BoatEntity;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntityMinecart.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntityMinecart.java
@@ -144,7 +144,7 @@ public interface IForgeEntityMinecart
      * current movement and cannot be overridden. The value however can never be
      * higher than getMaxCartSpeedOnRail().
      *
-     * @return
+     * @return Current max speed.
      */
     float getCurrentCartSpeedCapOnRail();
     void setCurrentCartSpeedCapOnRail(float value);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFluidState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFluidState.java
@@ -19,8 +19,6 @@
 
 package net.minecraftforge.common.extensions;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.entity.Entity;
 import net.minecraft.fluid.Fluid;
@@ -43,7 +41,7 @@ public interface IForgeFluidState
      * display material overlays, or if the entity can swim inside a block.
      *
      * @param world that is being tested.
-     * @param pos position thats being tested.
+     * @param pos position that's being tested.
      * @param entity that is being tested.
      * @param yToTest, primarily for testingHead, which sends the the eye level of the entity, other wise it sends a y that can be tested vs liquid height.
      * @param tag to test for.

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -261,7 +261,7 @@ public interface IForgeItem
 
     /**
      * Retrieves the normal 'lifespan' of this item when it is dropped on the ground
-     * as a EntityItem. This is in ticks, standard result is 6000, or 5 mins.
+     * as a EntityItem. This is in ticks, standard result is 6000, or 5 minutes.
      *
      * @param itemStack The current ItemStack
      * @param world     The world the entity is in
@@ -720,7 +720,7 @@ public interface IForgeItem
         return null;
     }
 
-    //TODO, properties dont exist anymore
+    //TODO, properties don't exist anymore
 //    default ImmutableMap<String, ITimeValue> getAnimationParameters(final ItemStack stack, final World world, final LivingEntity entity)
 //    {
 //        com.google.common.collect.ImmutableMap.Builder<String, ITimeValue> builder = ImmutableMap.builder();
@@ -735,7 +735,7 @@ public interface IForgeItem
      * @param shield   The shield in question
      * @param entity   The EntityLivingBase holding the shield
      * @param attacker The EntityLivingBase holding the ItemStack
-     * @retrun True if this ItemStack can disable the shield in question.
+     * @return True if this ItemStack can disable the shield in question.
      */
     default boolean canDisableShield(ItemStack stack, ItemStack shield, LivingEntity entity, LivingEntity attacker)
     {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -40,7 +40,6 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.stats.Stats;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.IFormattableTextComponent;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ToolType;
@@ -180,7 +179,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
     /**
      * ItemStack sensitive version of getItemEnchantability
      *
-     * @return the item echantability value
+     * @return the item Enchantability value
      */
     default int getItemEnchantability()
     {
@@ -208,7 +207,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
      * @param shield   The shield in question
      * @param entity   The EntityLivingBase holding the shield
      * @param attacker The EntityLivingBase holding the ItemStack
-     * @retrun True if this ItemStack can disable the shield in question.
+     * @return True if this ItemStack can disable the shield in question.
      */
     default boolean canDisableShield(ItemStack shield, LivingEntity entity, LivingEntity attacker)
     {
@@ -251,7 +250,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
 
     /**
      * Retrieves the normal 'lifespan' of this item when it is dropped on the ground
-     * as a EntityItem. This is in ticks, standard result is 6000, or 5 mins.
+     * as a EntityItem. This is in ticks, standard result is 6000, or 5 minutes.
      *
      * @param world     The world the entity is in
      * @return The normal lifespan in ticks.
@@ -262,7 +261,7 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundNBT>
     }
 
     /**
-     * Called by the default implemetation of EntityItem's onUpdate method, allowing
+     * Called by the default implementation of EntityItem's onUpdate method, allowing
      * for cleaner control over the update of the item without having to write a
      * subclass.
      *

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
@@ -152,6 +152,7 @@ public interface IForgeTileEntity extends ICapabilitySerializable<CompoundNBT>
                  // the tile entity data BEFORE the chunk data, you know, the OPPOSITE of what vanilla does!
                  // So we can not GUARANTEE that the world state is the real state for the block...
                  // So, once again in the long line of us having to accommodate BUKKIT breaking things,
+                 // So, once again in the long line of US having to accommodate BUKKIT breaking things,
                  // here it is, assume that the TE is only 1 cubic block. Problem with this is that it may
                  // cause the TileEntity renderer to error further down the line! But alas, nothing we can do.
                  cbb = new net.minecraft.util.math.AxisAlignedBB(pos.add(-1, 0, -1), pos.add(1, 1, 1));

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
@@ -152,7 +152,6 @@ public interface IForgeTileEntity extends ICapabilitySerializable<CompoundNBT>
                  // the tile entity data BEFORE the chunk data, you know, the OPPOSITE of what vanilla does!
                  // So we can not GUARANTEE that the world state is the real state for the block...
                  // So, once again in the long line of us having to accommodate BUKKIT breaking things,
-                 // So, once again in the long line of US having to accommodate BUKKIT breaking things,
                  // here it is, assume that the TE is only 1 cubic block. Problem with this is that it may
                  // cause the TileEntity renderer to error further down the line! But alas, nothing we can do.
                  cbb = new net.minecraft.util.math.AxisAlignedBB(pos.add(-1, 0, -1), pos.add(1, 1, 1));

--- a/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
@@ -86,7 +86,7 @@ public class LootModifierManager extends JsonReloadListener {
             //read in all data files from forge:loot_modifiers/global_loot_modifiers in order to do layering
             for(IResource iresource : resourceManagerIn.getAllResources(resourcelocation)) {
                 try (   InputStream inputstream = iresource.getInputStream();
-                        Reader reader = new BufferedReader(new InputStreamReader(inputstream, StandardCharsets.UTF_8));
+                        Reader reader = new BufferedReader(new InputStreamReader(inputstream, StandardCharsets.UTF_8))
                         ) {
                     JsonObject jsonobject = JSONUtils.fromJson(GSON_INSTANCE, reader, JsonObject.class);
                     boolean replace = jsonobject.get("replace").getAsBoolean();
@@ -145,7 +145,7 @@ public class LootModifierManager extends JsonReloadListener {
 
     /**
      * An immutable collection of the registered loot modifiers in layered order.
-     * @return
+     * @return  A collection of all loot modifiers, in layered order.
      */
     public Collection<IGlobalLootModifier> getAllLootMods() {
         return registeredLootModifiers.values();

--- a/src/main/java/net/minecraftforge/common/util/FakePlayer.java
+++ b/src/main/java/net/minecraftforge/common/util/FakePlayer.java
@@ -23,7 +23,6 @@ import javax.annotation.Nullable;
 
 import com.mojang.authlib.GameProfile;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.network.play.client.CClientSettingsPacket;

--- a/src/main/java/net/minecraftforge/common/util/FakePlayerFactory.java
+++ b/src/main/java/net/minecraftforge/common/util/FakePlayerFactory.java
@@ -20,9 +20,7 @@
 package net.minecraftforge.common.util;
 
 import java.lang.ref.WeakReference;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.UUID;
 
 import com.google.common.collect.Maps;

--- a/src/main/java/net/minecraftforge/common/util/RecipeMatcher.java
+++ b/src/main/java/net/minecraftforge/common/util/RecipeMatcher.java
@@ -80,7 +80,7 @@ public class RecipeMatcher
         if (data.nextClearBit(0) >= elements) //All items have been used, which means all tests have a match!
             return ret;
 
-        // We should be in a state where multiple tests are satified by multiple inputs. So we need to try a branching recursive test.
+        // We should be in a state where multiple tests are satisfied by multiple inputs. So we need to try a branching recursive test.
         // However for performance reasons, we should probably make that check a sub-set of the entire graph.
         if (backtrack(data, ret, 0, elements))
             return ret;

--- a/src/main/java/net/minecraftforge/common/world/BiomeGenerationSettingsBuilder.java
+++ b/src/main/java/net/minecraftforge/common/world/BiomeGenerationSettingsBuilder.java
@@ -27,10 +27,8 @@ import net.minecraft.world.gen.feature.StructureFeature;
 import net.minecraft.world.gen.surfacebuilders.ConfiguredSurfaceBuilder;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public class BiomeGenerationSettingsBuilder extends BiomeGenerationSettings.Builder

--- a/src/main/java/net/minecraftforge/common/world/ForgeWorldType.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeWorldType.java
@@ -81,7 +81,11 @@ public class ForgeWorldType extends ForgeRegistryEntry<ForgeWorldType>
 
     /**
      * Called from both the dedicated server and the world creation screen in the client.
-     * to construct the DimensionGEneratorSettings:
+     * to construct the DimensionGeneratorSettings:
+     * @param biomeRegistry Registry of biomes to be used within the chunk generator.
+     * @param dimensionSettingsRegistry Dimensional settings to be used within the chunk generator
+     * @param seed seed for the chunk generator to use for random generation.
+     * @param generatorSettings Additional generator settings.
      * @return The constructed chunk generator.
      */
     public ChunkGenerator createChunkGenerator(Registry<Biome> biomeRegistry, Registry<DimensionSettings> dimensionSettingsRegistry, long seed, String generatorSettings)

--- a/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
@@ -23,7 +23,6 @@ import net.minecraft.world.Difficulty;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**
  * DifficultyChangeEvent is fired when difficulty is changing. <br>

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -28,11 +28,11 @@ import net.minecraftforge.fml.LogicalSide;
 public class TickEvent extends Event
 {
     public enum Type {
-        WORLD, PLAYER, CLIENT, SERVER, RENDER;
+        WORLD, PLAYER, CLIENT, SERVER, RENDER
     }
 
     public enum Phase {
-        START, END;
+        START, END
     }
     public final Type type;
     public final LogicalSide side;

--- a/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
@@ -25,7 +25,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.eventbus.api.Event.HasResult;
 
 import javax.annotation.Nonnull;
 

--- a/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
+++ b/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
@@ -22,7 +22,6 @@ package net.minecraftforge.event.enchanting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.eventbus.api.Event;
 
 import javax.annotation.Nonnull;
 

--- a/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
@@ -23,7 +23,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**
  * This event gets fired whenever a entity mounts/dismounts another entity.<br>

--- a/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
@@ -24,7 +24,6 @@ import net.minecraft.util.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
-import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**
  * EntityTravelToDimensionEvent is fired before an Entity travels to a dimension.<br>

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
@@ -26,7 +26,7 @@ import net.minecraft.entity.item.ItemEntity;
  * Event that is fired when an EntityItem's age has reached its maximum
  * lifespan. Canceling this event will prevent the EntityItem from being
  * flagged as dead, thus staying its removal from the world. If canceled
- * it will add more time to the entities life equal to extraLife.
+ * it will add more time to the entity's life equal to extraLife.
  */
 @Cancelable
 public class ItemExpireEvent extends ItemEvent

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
@@ -27,7 +27,7 @@ import net.minecraft.entity.LivingEntity;
 /**
  * LivingDamageEvent is fired just before damage is applied to entity.<br>
  * At this point armor, potion and absorption modifiers have already been applied to damage - this is FINAL value.<br>
- * Also note that appropriate resources (like armor durability and absorption extra hearths) have already been consumed.<br>
+ * Also note that appropriate resources (like armor durability and absorption extra hearts) have already been consumed.<br>
  * This event is fired whenever an Entity is damaged in
  * {@link EntityLivingBase#damageEntity(DamageSource, float)} and
  * {@link EntityPlayer#damageEntity(DamageSource, float)}.<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
@@ -28,7 +28,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * Fired when the ender dragon or wither attempts to destroy a block and when ever a zombie attempts to break a door. Basically a event version of {@link Block#canEntityDestroy(IBlockState, IBlockAccess, BlockPos, Entity)}<br>
+ * Fired when the ender dragon or wither attempts to destroy a block and whenever a zombie attempts to break a door. Basically a event version of {@link Block#canEntityDestroy(IBlockState, IBlockAccess, BlockPos, Entity)}<br>
  * <br>
  * This event is {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
  * If this event is canceled, the block will not be destroyed.<br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -61,7 +61,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
      *   Drinking Potions/Milk
      *   Guarding with a sword
      *
-     * Cancel the event, or set the duration or <= 0 to prevent it from processing.
+     * Cancel the event, or set the duration to <= 0 to prevent it from processing.
      *
      */
     @Cancelable
@@ -76,7 +76,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
     /**
      * Fired every tick that a player is 'using' an item, see {@link Start} for info.
      *
-     * Cancel the event, or set the duration or <= 0 to cause the player to stop using the item.
+     * Cancel the event, or set the duration to <= 0 to cause the player to stop using the item.
      *
      */
     @Cancelable
@@ -98,7 +98,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
      * Duration on this event is how long the item had left in its count down before 'finishing'
      *
      * Canceling this event will prevent the Item from being notified that it has stopped being used,
-     * The only vanilla item this would effect are bows, and it would cause them NOT to fire there arrow.
+     * The only vanilla item this would effect are bows, and it would cause them NOT to fire their arrow.
      */
     @Cancelable
     public static class Stop extends LivingEntityUseItemEvent
@@ -111,7 +111,7 @@ public class LivingEntityUseItemEvent extends LivingEvent
 
     /**
      * Fired after an item has fully finished being used.
-     * The item has been notified that it was used, and the item/result stacks reflect after that state.
+     * The item has been notified that it was used, and the item/result stacks reflect that used state.
      * This means that when this is fired for a Potion, the potion effect has already been applied.
      *
      * {@link LivingEntityUseItemEvent#item} is a copy of the item BEFORE it was used.

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -26,7 +26,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityEvent;
 
 /**
- * LivingEvent is fired whenever an event involving Living entities occurs.<br>
+ * LivingEvent is fired whenever an event involving Living Entities occurs.<br>
  * If a method utilizes this {@link net.minecraftforge.eventbus.api.Event} as its parameter, the method will
  * receive every child event of this class.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
@@ -24,7 +24,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraftforge.eventbus.api.Cancelable;
 
 /**
- * Event for when an entity drops experience on its death, can be used to change
+ * Event for when an entity drops experience on its death, and can be used to change
  * the amount of experience points dropped or completely prevent dropping of experience
  * by canceling the event.
  */

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -78,7 +78,8 @@ public class LivingSpawnEvent extends LivingEvent
         private final SpawnReason spawnReason;
 
         /**
-         * CheckSpawn is fired when an Entity is about to be spawned.
+         * CheckSpawn is fired when an Entity is about to be spawned. <br>
+         * This includes natural spawning and mob spawners.
          * @param entity the spawning entity
          * @param world the world to spawn in
          * @param x x coordinate
@@ -86,6 +87,7 @@ public class LivingSpawnEvent extends LivingEvent
          * @param z z coordinate
          * @param spawner position of the MobSpawner
          *                  null if it this spawn is coming from a WorldSpawner
+         * @param spawnReason the cause of the Entity Spawn.
          */
         public CheckSpawn(MobEntity entity, IWorld world, double x, double y, double z, @Nullable AbstractSpawner spawner, SpawnReason spawnReason)
         {
@@ -112,8 +114,10 @@ public class LivingSpawnEvent extends LivingEvent
     }
 
     /**
-     * SpecialSpawn is fired when an Entity is to be spawned.<br>
+     * SpecialSpawn is fired when an Entity is about to be spawned.<br>
      * This allows you to do special initializers in the new entity.<br>
+     * This event occurs on natural spawns, monster spawners, spawn eggs,<br>
+     * fish-in-buckets, the Wandering Trader, and portal-related spawns. <br>
      * <br>
      * This event is fired via the {@link ForgeEventFactory#doSpecialSpawn(EntityLiving, World, float, float, float)}.<br>
      * <br>
@@ -132,7 +136,17 @@ public class LivingSpawnEvent extends LivingEvent
         private final SpawnReason spawnReason;
 
         /**
-         * @param spawner the position of a TileEntity or approximate position of an entity that initiated the spawn if any
+         * SpecialSpawn is fired when an Entity is about to be spawned.
+         * This event occurs on natural spawns, monster spawners, spawn eggs,
+         * fish-in-buckets, the Wandering Trader, and portal-related spawns.
+         * @param entity the spawning entity
+         * @param world the world to spawn in
+         * @param x x coordinate
+         * @param y y coordinate
+         * @param z z coordinate
+         * @param spawner position of the MobSpawner
+         *                  null if it this spawn is coming from a WorldSpawner
+         * @param spawnReason the cause of the Entity Spawn.
          */
         public SpecialSpawn(MobEntity entity, World world, double x, double y, double z, @Nullable AbstractSpawner spawner, SpawnReason spawnReason)
         {

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -29,8 +29,6 @@ import net.minecraft.entity.SpawnReason;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 
-import net.minecraftforge.eventbus.api.Event.HasResult;
-
 /**
  * LivingSpawnEvent is fired for any events associated with Living Entities spawn status. <br>
  * If a method utilizes this {@link Event} as its parameter, the method will
@@ -115,7 +113,7 @@ public class LivingSpawnEvent extends LivingEvent
 
     /**
      * SpecialSpawn is fired when an Entity is to be spawned.<br>
-     * This allows you to do special inializers in the new entity.<br>
+     * This allows you to do special initializers in the new entity.<br>
      * <br>
      * This event is fired via the {@link ForgeEventFactory#doSpecialSpawn(EntityLiving, World, float, float, float)}.<br>
      * <br>
@@ -134,7 +132,7 @@ public class LivingSpawnEvent extends LivingEvent
         private final SpawnReason spawnReason;
 
         /**
-         * @param spawner the position of a tileentity or approximate position of an entity that initiated the spawn if any
+         * @param spawner the position of a TileEntity or approximate position of an entity that initiated the spawn if any
          */
         public SpecialSpawn(MobEntity entity, World world, double x, double y, double z, @Nullable AbstractSpawner spawner, SpawnReason spawnReason)
         {

--- a/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
@@ -28,10 +28,8 @@ import net.minecraft.potion.EffectInstance;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Cancelable;
 
-import net.minecraftforge.eventbus.api.Event.HasResult;
-
 /**
- * This Event and its subevents gets fired from  {@link EntityLivingBase} on the  {@link MinecraftForge#EVENT_BUS}.<br>
+ * This Event and its subevents gets fired from {@link EntityLivingBase} on the {@link MinecraftForge#EVENT_BUS}.<br>
  */
 public class PotionEvent extends LivingEvent
 {
@@ -44,7 +42,7 @@ public class PotionEvent extends LivingEvent
         this.effect = effect;
     }
     /**
-     * Retuns the PotionEffect.
+     * @return the PotionEffect.
      */
     @Nullable
     public EffectInstance getPotionEffect()
@@ -136,7 +134,7 @@ public class PotionEvent extends LivingEvent
         }
 
         /**
-         * @return the added PotionEffect. This is the umerged PotionEffect if the old PotionEffect is not null.
+         * @return the added PotionEffect. This is the unmerged PotionEffect if the old PotionEffect is not null.
          */
         @Override
         @Nonnull
@@ -146,7 +144,7 @@ public class PotionEvent extends LivingEvent
         }
 
         /**
-         * @return the old PotionEffect. THis can be null if the entity did not have an effect of this kind before.
+         * @return the old PotionEffect. This can be null if the entity did not have an effect of this kind before.
          */
         @Nullable
         public EffectInstance getOldPotionEffect()

--- a/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
@@ -26,10 +26,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.EntityEvent;
-import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
-
-import net.minecraftforge.eventbus.api.Event.HasResult;
 
 /**
  * ZombieEvent is fired whenever a zombie is spawned for aid.

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -74,7 +74,7 @@ public class CriticalHitEvent extends PlayerEvent
 
     /**
     * The damage modifier for the hit.<br>
-    * This is by default 1.5F for ciritcal hits and 1F for normal hits .
+    * This is by default 1.5F for critical hits and 1F for normal hits .
     */
     public float getDamageModifier()
     {
@@ -82,8 +82,8 @@ public class CriticalHitEvent extends PlayerEvent
     }
 
     /**
-    * The orignal damage modifier for the hit wthout any changes.<br>
-    * This is 1.5F for ciritcal hits and 1F for normal hits .
+    * The original damage modifier for the hit without any changes.<br>
+    * This is 1.5F for critical hits and 1F for normal hits .
     */
     public float getOldDamageModifier()
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -62,7 +62,7 @@ public class ItemFishedEvent extends PlayerEvent
     /**
      * Specifies the amount of damage that the fishing rod should take.
      * This is not added to the pre-existing damage to be taken.
-     * @param rodDamage The damage the rod will take. Must be nonnegative
+     * @param rodDamage The damage the rod will take. Must be non-negative
      */
     public void damageRodBy(@Nonnegative int rodDamage)
     {
@@ -81,7 +81,7 @@ public class ItemFishedEvent extends PlayerEvent
     }
 
     /**
-     * Use this to stuff related to the hook itself, like the position of the bobber.
+     * Use this to get stuff related to the hook itself, like the position of the bobber.
      */
     public FishingBobberEntity getHookEntity()
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -36,7 +36,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraftforge.event.entity.living.LivingEvent;
-import net.minecraftforge.eventbus.api.Event;
 
 import javax.annotation.Nonnull;
 

--- a/src/main/java/net/minecraftforge/event/entity/player/UseHoeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/UseHoeEvent.java
@@ -41,7 +41,7 @@ import javax.annotation.Nonnull;
 @Deprecated
 public class UseHoeEvent extends PlayerEvent
 {
-    private final ItemUseContext context;;
+    private final ItemUseContext context;
 
     public UseHoeEvent(ItemUseContext context)
     {

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -22,7 +22,6 @@ package net.minecraftforge.event.world;
 import java.util.EnumSet;
 import java.util.List;
 
-import net.minecraft.block.NetherPortalBlock;
 import net.minecraft.block.PortalSize;
 import net.minecraft.block.BlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -30,7 +29,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.Direction;
 import net.minecraft.world.IWorld;
@@ -46,8 +44,6 @@ import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import net.minecraftforge.eventbus.api.Event.HasResult;
 
 public class BlockEvent extends Event
 {

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -37,10 +37,10 @@ public abstract class PistonEvent extends BlockEvent
     private final PistonMoveType moveType;
 
     /**
-     * @param world
-     * @param pos - The position of the piston
-     * @param direction - The direction of the piston
-     * @param direction - The move direction of the piston
+     * @param world The world where the piston event is occurring.
+     * @param pos The position of the piston
+     * @param direction The direction of the piston
+     * @param moveType If the piston is extending or retracting.
      */
     public PistonEvent(World world, BlockPos pos, Direction direction, PistonMoveType moveType)
     {

--- a/src/main/java/net/minecraftforge/event/world/RegisterDimensionsEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/RegisterDimensionsEvent.java
@@ -30,7 +30,7 @@ import net.minecraftforge.common.DimensionManager.SavedEntry;
 import net.minecraftforge.eventbus.api.Event;
 
 /**
- * Register all of your custom ModDimensons here, fired during server loading when
+ * Register all of your custom ModDimensions here, fired during server loading when
  * dimension data is read from the world file.
  *
  * Contains a list of missing entries. Registering an entry with the DimensionManger

--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -34,7 +34,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.IRegistryDelegate;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -294,7 +293,7 @@ public class FluidStack
     /**
      * Determines if the Fluids are equal and this stack is larger.
      *
-     * @param other
+     * @param other the FluidStack for comparison.
      * @return true if this FluidStack contains the other FluidStack (same fluid and >= amount)
      */
     public boolean containsFluid(@Nonnull FluidStack other)
@@ -305,8 +304,7 @@ public class FluidStack
     /**
      * Determines if the FluidIDs, Amounts, and NBT Tags are all equal.
      *
-     * @param other
-     *            - the FluidStack for comparison
+     * @param other the FluidStack for comparison
      * @return true if the two FluidStacks are exactly the same
      */
     public boolean isFluidStackIdentical(FluidStack other)
@@ -318,8 +316,7 @@ public class FluidStack
      * Determines if the FluidIDs and NBT Tags are equal compared to a registered container
      * ItemStack. This does not check amounts.
      *
-     * @param other
-     *            The ItemStack for comparison
+     * @param other The ItemStack for comparison
      * @return true if the Fluids (IDs and NBT Tags) are the same
      */
     public boolean isFluidEqual(@Nonnull ItemStack other)

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -499,7 +499,7 @@ public class FluidUtil
      *
      * @param player    Player who places the fluid. May be null for blocks like dispensers.
      * @param world     World to place the fluid in
-     * @param hand
+     * @param hand      The player's hand that is holding an item that should interact with the fluid handler block.
      * @param pos       The position in the world to place the fluid block
      * @param container The fluid container holding the fluidStack to place
      * @param resource  The fluidStack to place
@@ -526,7 +526,7 @@ public class FluidUtil
      *
      * @param player      Player who places the fluid. May be null for blocks like dispensers.
      * @param world       World to place the fluid in
-     * @param hand
+     * @param hand        The player's hand that is holding an item that should interact with the fluid handler block.
      * @param pos         The position in the world to place the fluid block
      * @param fluidSource The fluid source holding the fluidStack to place
      * @param resource    The fluidStack to place.
@@ -550,7 +550,7 @@ public class FluidUtil
             return false;
         }
 
-        BlockItemUseContext context = new BlockItemUseContext(new ItemUseContext(player, hand, new BlockRayTraceResult(Vector3d.ZERO, Direction.UP, pos, false))); //TODO: This neds proper context...
+        BlockItemUseContext context = new BlockItemUseContext(new ItemUseContext(player, hand, new BlockRayTraceResult(Vector3d.ZERO, Direction.UP, pos, false))); //TODO: This needs proper context...
 
         // Check that we can place the fluid at the destination
         BlockState destBlockState = world.getBlockState(pos);

--- a/src/main/java/net/minecraftforge/fluids/ForgeFlowingFluid.java
+++ b/src/main/java/net/minecraftforge/fluids/ForgeFlowingFluid.java
@@ -29,7 +29,6 @@ import net.minecraft.fluid.FluidState;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.state.StateContainer;
-import net.minecraft.tags.FluidTags;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;

--- a/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
+++ b/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
@@ -25,7 +25,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Implement this interface on Block classes which represent world-placeable Fluids.
@@ -61,7 +60,7 @@ public interface IFluidBlock
      *
      * @param action
      *            If SIMULATE, the drain will only be simulated.
-     * @return
+     * @return the FluidStack removed from the world.
      */
     @Nonnull
     FluidStack drain(World world, BlockPos pos, IFluidHandler.FluidAction action);
@@ -70,7 +69,7 @@ public interface IFluidBlock
      * Check to see if a block can be drained. This method should be called by devices such as
      * pumps.
      *
-     * @return
+     * @return true if the block contains a fluid that can be drained.
      */
     boolean canDrain(World world, BlockPos pos);
 
@@ -81,7 +80,7 @@ public interface IFluidBlock
      * If the return value is negative. It will be treated as filling the block
      * from the top down instead of bottom up.
      *
-     * @return
+     * @return 0.0 to 1.0 amount that the block is filled with liquid, or -1.0 to 0.0 that the block is filled from the top down.
      */
     float getFilledPercentage(World world, BlockPos pos);
 }

--- a/src/main/java/net/minecraftforge/fluids/IFluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/IFluidTank.java
@@ -22,7 +22,6 @@ package net.minecraftforge.fluids;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * This interface represents a Fluid Tank. IT IS NOT REQUIRED but is provided for convenience.

--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
@@ -20,7 +20,6 @@
 package net.minecraftforge.fluids.capability;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import net.minecraftforge.fluids.*;
 

--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandlerItem.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandlerItem.java
@@ -20,7 +20,6 @@
 package net.minecraftforge.fluids.capability;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/EmptyFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/EmptyFluidHandler.java
@@ -20,7 +20,6 @@
 package net.minecraftforge.fluids.capability.templates;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
@@ -23,10 +23,8 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.IFluidHandler;
-import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.function.Predicate;
 
 /**

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/VoidFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/VoidFluidHandler.java
@@ -23,7 +23,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * VoidFluidHandler is a template fluid handler that can be filled indefinitely without ever getting full.

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/BlockWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/BlockWrapper.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.fluids.capability.wrappers;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.item.*;
 import net.minecraft.util.Direction;
-import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;

--- a/src/main/java/net/minecraftforge/fml/DistExecutor.java
+++ b/src/main/java/net/minecraftforge/fml/DistExecutor.java
@@ -95,7 +95,7 @@ public final class DistExecutor
     }
 
     /**
-     * Runs the supplied Runnable on the speicified side. Same warnings apply as {@link #callWhenOn(Dist, Supplier)}.
+     * Runs the supplied Runnable on the specified side. Same warnings apply as {@link #callWhenOn(Dist, Supplier)}.
      *
      * This method can cause unexpected ClassNotFound exceptions.
      *
@@ -109,7 +109,7 @@ public final class DistExecutor
         unsafeRunWhenOn(dist, toRun);
     }
     /**
-     * Runs the supplied Runnable on the speicified side. Same warnings apply as {@link #unsafeCallWhenOn(Dist, Supplier)}.
+     * Runs the supplied Runnable on the specified side. Same warnings apply as {@link #unsafeCallWhenOn(Dist, Supplier)}.
      *
      * This method can cause unexpected ClassNotFoundException problems in common scenarios. Understand the pitfalls of
      * the way the class verifier works to load classes before using this.

--- a/src/main/java/net/minecraftforge/fml/ForgeI18n.java
+++ b/src/main/java/net/minecraftforge/fml/ForgeI18n.java
@@ -38,7 +38,7 @@ import java.util.regex.Pattern;
 
 import static net.minecraftforge.fml.Logging.CORE;
 
-//TODO, this should be re-evaluated now that ITextComponents are passed everywhere instaed of strings.
+//TODO, this should be re-evaluated now that ITextComponents are passed everywhere instead of strings.
 public class ForgeI18n {
     private static final Logger LOGGER = LogManager.getLogger();
     // From FontRenderer.renderCharAtPos

--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -33,7 +33,6 @@ import net.minecraftforge.fml.loading.LoadingModList;
 import net.minecraftforge.fml.loading.moddiscovery.InvalidModIdentifier;
 import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
-import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
 import net.minecraftforge.fml.loading.progress.StartupMessageManager;
 import net.minecraftforge.fml.network.FMLNetworkConstants;
 import net.minecraftforge.fml.network.NetworkRegistry;

--- a/src/main/java/net/minecraftforge/fml/ModLoadingStage.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingStage.java
@@ -41,7 +41,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;

--- a/src/main/java/net/minecraftforge/fml/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/fml/RegistryObject.java
@@ -100,7 +100,7 @@ public final class RegistryObject<T extends IForgeRegistryEntry<? super T>> impl
                 {
                     this.registry = RegistryManager.ACTIVE.getRegistry(baseType);
                     if (registry == null)
-                        throw new IllegalStateException("Unable to find registry for type " + baseType.getName() + " for mod \"" + modid + "\". Check the 'caused by' to see futher stack.", callerStack);
+                        throw new IllegalStateException("Unable to find registry for type " + baseType.getName() + " for mod \"" + modid + "\". Check the 'caused by' to see further stack.", callerStack);
                 }
                 if (pred.test(registry.getRegistryName()))
                     RegistryObject.this.value = registry.containsKey(RegistryObject.this.name) ? (T)registry.getValue(RegistryObject.this.name) : null;

--- a/src/main/java/net/minecraftforge/fml/WorldPersistenceHooks.java
+++ b/src/main/java/net/minecraftforge/fml/WorldPersistenceHooks.java
@@ -22,7 +22,6 @@ package net.minecraftforge.fml;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.world.storage.IServerConfiguration;
 import net.minecraft.world.storage.SaveFormat;
-import net.minecraftforge.fml.common.thread.EffectiveSide;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
@@ -549,7 +549,7 @@ public class GuiUtils
 
             mStack.push();
             Matrix4f mat = mStack.getLast().getMatrix();
-            //TODO, lots of unnessesary GL calls here, we can buffer all these together.
+            //TODO, lots of unnecessary GL calls here, we can buffer all these together.
             drawGradientRect(mat, zLevel, tooltipX - 3, tooltipY - 4, tooltipX + tooltipTextWidth + 3, tooltipY - 3, backgroundColor, backgroundColor);
             drawGradientRect(mat, zLevel, tooltipX - 3, tooltipY + tooltipHeight + 3, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 4, backgroundColor, backgroundColor);
             drawGradientRect(mat, zLevel, tooltipX - 3, tooltipY - 3, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 3, backgroundColor, backgroundColor);

--- a/src/main/java/net/minecraftforge/fml/client/gui/screen/LoadingErrorScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/screen/LoadingErrorScreen.java
@@ -28,7 +28,6 @@ import net.minecraft.client.gui.widget.list.ExtendedList;
 import net.minecraft.util.IReorderingProcessor;
 import net.minecraft.util.Util;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.ITextProperties;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.ForgeI18n;

--- a/src/main/java/net/minecraftforge/fml/client/gui/screen/ModListScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/screen/ModListScreen.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
-import cpw.mods.modlauncher.Environment;
 import net.minecraft.util.text.*;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.apache.commons.lang3.tuple.Pair;
@@ -118,7 +117,7 @@ public class ModListScreen extends Screen
     private SortType sortType = SortType.NORMAL;
 
     /**
-     * @param parentScreen
+     * @param parentScreen the parent display screen.
      */
     public ModListScreen(Screen parentScreen)
     {

--- a/src/main/java/net/minecraftforge/fml/client/gui/widget/ExtendedButton.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/widget/ExtendedButton.java
@@ -62,7 +62,7 @@ public class ExtendedButton extends Button
             int ellipsisWidth = mc.fontRenderer.getStringWidth("...");
 
             if (strWidth > width - 6 && strWidth > ellipsisWidth)
-                //TODO, srg names make it hard to figure out how to append to an ITextProperties from this trim operation, wraping this in StringTextComponent is kinda dirty.
+                //TODO, srg names make it hard to figure out how to append to an ITextProperties from this trim operation, wrapping this in StringTextComponent is kinda dirty.
                 buttonText = new StringTextComponent(mc.fontRenderer.func_238417_a_(buttonText, width - 6 - ellipsisWidth).getString() + "...");
 
             drawCenteredString(mStack, mc.fontRenderer, buttonText, this.x + this.width / 2, this.y + (this.height - 8) / 2, getFGColor());

--- a/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
@@ -22,7 +22,6 @@ package net.minecraftforge.fml.client.registry;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;

--- a/src/main/java/net/minecraftforge/fml/common/LoaderException.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoaderException.java
@@ -18,7 +18,6 @@
  */
 
 package net.minecraftforge.fml.common;
-import net.minecraftforge.fml.common.EnhancedRuntimeException.WrappedPrintStream;
 
 
 public class LoaderException extends EnhancedRuntimeException

--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -22,7 +22,6 @@ package net.minecraftforge.fml.config;
 import com.electronwill.nightconfig.core.CommentedConfig;
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.electronwill.nightconfig.toml.TomlFormat;
-import it.unimi.dsi.fastutil.bytes.Byte2ByteOpenCustomHashMap;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.fml.network.FMLHandshakeMessages;
 import net.minecraftforge.fml.network.NetworkEvent;
@@ -46,8 +45,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import static cpw.mods.modlauncher.api.LamdbaExceptionUtils.rethrowFunction;
 
 public class ConfigTracker {
     private static final Logger LOGGER = LogManager.getLogger();

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
@@ -19,10 +19,7 @@
 
 package net.minecraftforge.fml.event.lifecycle;
 
-import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraftforge.fml.ModContainer;
-
-import java.util.function.Supplier;
 
 /**
  * This is the second of four commonly called events during mod lifecycle startup.

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLFingerprintViolationEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLFingerprintViolationEvent.java
@@ -23,14 +23,12 @@ import java.io.File;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import net.minecraftforge.fml.common.Mod;
-
 
 /**
  * DEPRECATED WITHOUT REPLACEMENT. REMOVE FROM YOUR CODE!!!
  * IT HAS NEVER BEEN FIRED IN 1.13+ AND WILL NEVER FIRE AGAIN!!!
  * FIRE.JPG FIRE.JPG FIRE.JPG
- * DELET THIS
+ * DELETE THIS
  */
 @Deprecated
 public class FMLFingerprintViolationEvent extends ModLifecycleEvent

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
@@ -23,7 +23,6 @@ import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModContainer;
 
-import java.util.Arrays;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 

--- a/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLanguageProvider.java
+++ b/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLanguageProvider.java
@@ -20,9 +20,7 @@
 package net.minecraftforge.fml.javafmlmod;
 
 import cpw.mods.modlauncher.api.LamdbaExceptionUtils;
-import net.minecraftforge.fml.ModLoadingException;
 import net.minecraftforge.fml.ModLoadingStage;
-import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.forgespi.language.ILifecycleEvent;
 import net.minecraftforge.forgespi.language.IModLanguageProvider;
 import net.minecraftforge.forgespi.language.IModInfo;

--- a/src/main/java/net/minecraftforge/fml/network/FMLHandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLHandshakeHandler.java
@@ -195,7 +195,7 @@ public class FMLHandshakeHandler {
         LOGGER.debug(FMLHSMARKER, "Received client indexed reply {} of type {}", message.getAsInt(), message.getClass().getName());
         boolean removed = this.sentMessages.removeIf(i-> i == message.getAsInt());
         if (!removed) {
-            LOGGER.error(FMLHSMARKER, "Recieved unexpected index {} in client reply", message.getAsInt());
+            LOGGER.error(FMLHSMARKER, "Received unexpected index {} in client reply", message.getAsInt());
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/network/FMLHandshakeMessages.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLHandshakeMessages.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.IntSupplier;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;

--- a/src/main/java/net/minecraftforge/fml/network/FMLLoginWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLLoginWrapper.java
@@ -59,7 +59,7 @@ public class FMLLoginWrapper {
             data = new PacketBuffer(payload.readBytes(payloadLength));
         }
         final int loginSequence = packet.getLoginIndex();
-        LOGGER.debug(FMLHandshakeHandler.FMLHSMARKER, "Recieved login wrapper packet event for channel {} with index {}", targetNetworkReceiver, loginSequence);
+        LOGGER.debug(FMLHandshakeHandler.FMLHSMARKER, "Received login wrapper packet event for channel {} with index {}", targetNetworkReceiver, loginSequence);
         final NetworkEvent.Context context = new NetworkEvent.Context(wrappedContext.getNetworkManager(), wrappedContext.getDirection(), new PacketDispatcher((rl, buf) -> {
             LOGGER.debug(FMLHandshakeHandler.FMLHSMARKER, "Dispatching wrapped packet reply for channel {} with index {}", rl, loginSequence);
             wrappedContext.getPacketDispatcher().sendPacket(WRAPPER, this.wrapPacket(rl, buf));

--- a/src/main/java/net/minecraftforge/fml/network/NetworkDirection.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkDirection.java
@@ -84,7 +84,7 @@ public enum NetworkDirection
         return logicalSide;
     }
 
-    public LogicalSide getReceptionSide() { return reply().logicalSide; };
+    public LogicalSide getReceptionSide() { return reply().logicalSide; }
 
     @SuppressWarnings("unchecked")
     public <T extends IPacket<?>> ICustomPacket<T> buildPacket(Pair<PacketBuffer,Integer> packetData, ResourceLocation channelName)

--- a/src/main/java/net/minecraftforge/fml/network/NetworkEvent.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkEvent.java
@@ -130,7 +130,7 @@ public class NetworkEvent extends Event
     }
 
     public enum RegistrationChangeType {
-        REGISTER, UNREGISTER;
+        REGISTER, UNREGISTER
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
@@ -181,7 +181,7 @@ public class NetworkHooks
      *
      * @param player The player to open the GUI for
      * @param containerSupplier A supplier of container properties including the registry name of the container
-     * @param pos A block pos, which will be encoded into the auxillary data for this request
+     * @param pos A block pos, which will be encoded into the auxiliary data for this request
      */
     public static void openGui(ServerPlayerEntity player, INamedContainerProvider containerSupplier, BlockPos pos)
     {

--- a/src/main/java/net/minecraftforge/fml/network/NetworkInstance.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkInstance.java
@@ -25,11 +25,9 @@ import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.IEventListener;
-import net.minecraftforge.fml.network.simple.SimpleChannel;
 
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 

--- a/src/main/java/net/minecraftforge/fml/network/simple/SimpleChannel.java
+++ b/src/main/java/net/minecraftforge/fml/network/simple/SimpleChannel.java
@@ -24,7 +24,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.IPacket;
 import net.minecraft.network.PacketBuffer;
-import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.fml.network.*;
 import org.apache.commons.lang3.tuple.Pair;
 

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
@@ -195,7 +195,7 @@ public class LibraryManager
     {
         if (processed.contains(file))
         {
-            LOGGER.debug("File already proccessed {}, Skipping", file.getAbsolutePath());
+            LOGGER.debug("File already processed {}, Skipping", file.getAbsolutePath());
             return null;
         }
         JarFile jar = null;
@@ -227,7 +227,7 @@ public class LibraryManager
 
         JarEntry manifest_entry = jar.getJarEntry(JarFile.MANIFEST_NAME);
         if (manifest_entry == null)
-            manifest_entry = jar.stream().filter(e -> JarFile.MANIFEST_NAME.equals(e.getName().toUpperCase(Locale.ENGLISH))).findFirst().get(); //We know that getManifest returned non-null so we know there is *some* entry that matches the manifest file. So we dont need to empty check.
+            manifest_entry = jar.stream().filter(e -> JarFile.MANIFEST_NAME.equals(e.getName().toUpperCase(Locale.ENGLISH))).findFirst().get(); //We know that getManifest returned non-null so we know there is *some* entry that matches the manifest file. So we don't need to empty check.
 
         attrs = jar.getManifest().getMainAttributes();
 
@@ -465,7 +465,7 @@ public class LibraryManager
                 }
                 else if (!list.contains(file))
                 {
-                    LOGGER.debug("  Duplicte command line mod detected {} ({})", mod, file.getAbsolutePath());
+                    LOGGER.debug("  Duplicate command line mod detected {} ({})", mod, file.getAbsolutePath());
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
@@ -442,7 +442,14 @@ public class LibraryManager
         return merged;
     }
 
+    // TODO: remove in 1.17.
+    @Deprecated
     public static List<File> gatherLegacyCanidates(File mcDir)
+    {
+        return gatherLegacyCandidates(mcDir);
+    }
+
+    public static List<File> gatherLegacyCandidates(File mcDir)
     {
         List<File> list = new ArrayList<>();
 

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/ModList.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/ModList.java
@@ -74,7 +74,7 @@ public class ModList
                     create(listFile, mcdir); //Create will recursively create parent lists, so after this run everything should be populated.
             }
         }
-        return ImmutableList.copyOf(cache.values()); //TODO: Do we care about order? I dont think so as we resolve all libs in a flat map.
+        return ImmutableList.copyOf(cache.values()); //TODO: Do we care about order? I don't think so as we resolve all libs in a flat map.
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
@@ -90,7 +90,7 @@ public class ServerLifecycleHooks
     {
         currentServer = server;
         currentServer.getServerStatusResponse().setForgeData(new FMLStatusPing()); //gathers NetworkRegistry data
-        // on the dedi server we need to force the stuff to setup properly
+        // on the dedicated server we need to force the stuff to setup properly
         LogicalSidedProvider.setServer(()->server);
         ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SERVER, getServerConfigPath(server));
         return !MinecraftForge.EVENT_BUS.post(new FMLServerAboutToStartEvent(server));

--- a/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
@@ -28,8 +28,6 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 
-import java.util.concurrent.Callable;
-
 public class CapabilityItemHandler
 {
     @CapabilityInject(IItemHandler.class)

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -25,9 +25,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import javax.annotation.Nonnull;
 
-
-import javax.annotation.Nonnull;
-
 public interface IItemHandler
 {
     /**

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.items;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.DropperBlock;
 import net.minecraft.block.HopperBlock;
 import net.minecraft.item.ItemStack;
@@ -31,7 +30,6 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
-import net.minecraftforge.common.util.LazyOptional;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
@@ -31,11 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Exposes the armor or hands inventory of an {@link EntityLivingBase} as an {@link IItemHandler} using {@link EntityLivingBase#getItemStackFromSlot} and
  * {@link EntityLivingBase#setItemStackToSlot}.

--- a/src/main/java/net/minecraftforge/logging/ModelLoaderErrorMessage.java
+++ b/src/main/java/net/minecraftforge/logging/ModelLoaderErrorMessage.java
@@ -25,14 +25,12 @@ import com.google.common.collect.Multimap;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.BlockModelShapes;
 import net.minecraft.client.renderer.model.ModelResourceLocation;
-import net.minecraft.item.Item;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import org.apache.logging.log4j.message.SimpleMessage;
 
 import java.util.Collection;
-import java.util.function.Function;
 
 import static net.minecraftforge.client.model.ModelLoader.getInventoryVariant;
 

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -21,7 +21,6 @@ package net.minecraftforge.registries;
 
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.RegistryObject;
@@ -34,8 +33,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
-
-import com.google.common.reflect.TypeToken;
 
 /**
  * Utility class to help with managing registry entries.

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -67,7 +67,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
  */
 public class ForgeRegistries
 {
-    static { init(); } // This must be above the fields so we guarantee it's run before findRegistry is called. Yay static inializers
+    static { init(); } // This must be above the fields so we guarantee it's run before findRegistry is called. Yay static initializers
 
     // Game objects
     public static final IForgeRegistry<Block> BLOCKS = RegistryManager.ACTIVE.getRegistry(Block.class);
@@ -164,7 +164,7 @@ public class ForgeRegistries
     }
 
     /**
-     * This function is just to make sure static inializers in other classes have run and setup their registries before we query them.
+     * This function is just to make sure static initializers in other classes have run and setup their registries before we query them.
      */
     private static void init()
     {

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -369,7 +369,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         if (defaultKey != null && defaultKey.equals(key))
         {
             if (this.defaultValue != null)
-                throw new IllegalStateException(String.format("Attemped to override already set default value. This is not allowed: The object %s (name %s)", value, key));
+                throw new IllegalStateException(String.format("Attempted to override already set default value. This is not allowed: The object %s (name %s)", value, key));
             this.defaultValue = value;
         }
 
@@ -1025,7 +1025,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
                 LOGGER.debug(REGISTRIES,"  Remapping {} -> {}.", remap.key, newName);
 
                 missing.remove(remap.key);
-                //I don't think this will work, but I dont think it ever worked.. the item is already in the map with a different id... we want to fix that..
+                // todo: I don't think this will work, but I don't think it ever worked.. the item is already in the map with a different id... we want to fix that..
                 int realId = this.add(remap.id, remap.getTarget());
                 if (realId != remap.id)
                     LOGGER.warn(REGISTRIES,"Registered object did not get ID it asked for. Name: {} Type: {} Expected: {} Got: {}", newName, this.getRegistrySuperType(), remap.id, realId);

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 
 /**
  * Default implementation of IForgeRegistryEntry, this is necessary to reduce redundant code.
- * This also enables the registrie's ability to manage delegates. Which are automatically updated
+ * This also enables the registry's ability to manage delegates. Which are automatically updated
  * if another entry overrides existing ones in the registry.
  */
 @SuppressWarnings("unchecked")

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -74,7 +74,6 @@ import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.common.world.ForgeWorldType;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.RegistryEvent.MissingMappings;
-import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.ModLoadingStage;
 import net.minecraftforge.fml.common.EnhancedRuntimeException;
@@ -93,7 +92,6 @@ import java.lang.reflect.Field;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -108,7 +106,7 @@ import static net.minecraftforge.registries.ForgeRegistries.Keys.*;
 public class GameData
 {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final int MAX_VARINT = Integer.MAX_VALUE - 1; //We were told it is their intention to have everything in a reg be unlimited, so assume that until we find cases where it isnt.
+    private static final int MAX_VARINT = Integer.MAX_VALUE - 1; //We were told it is their intention to have everything in a reg be unlimited, so assume that until we find cases where it isn't.
 
     private static final ResourceLocation BLOCK_TO_ITEM = new ResourceLocation("minecraft:blocktoitemmap");
     private static final ResourceLocation BLOCKSTATE_TO_ID = new ResourceLocation("minecraft:blockstatetoid");
@@ -885,7 +883,7 @@ public class GameData
     {
         ForgeRegistry<T> active  = pool.getRegistry(name);
         if (active == null)
-            return; // We've already asked the user if they wish to continue. So if the reg isnt found just assume the user knows and accepted it.
+            return; // We've already asked the user if they wish to continue. So if the reg isn't found just assume the user knows and accepted it.
         ForgeRegistry<T> _new = to.getRegistry(name, RegistryManager.ACTIVE);
         snap.aliases.forEach(_new::addAlias);
         snap.blocked.forEach(_new::block);

--- a/src/main/java/net/minecraftforge/server/command/ChunkGenWorker.java
+++ b/src/main/java/net/minecraftforge/server/command/ChunkGenWorker.java
@@ -27,7 +27,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.server.ServerWorld;
-import net.minecraft.world.DimensionType;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.IChunk;
 import net.minecraftforge.common.WorldWorkerManager.IWorker;

--- a/src/main/java/net/minecraftforge/server/command/CommandDimensions.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandDimensions.java
@@ -29,7 +29,6 @@ import net.minecraft.world.DimensionType;
 import net.minecraft.world.server.ServerWorld;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/net/minecraftforge/server/permission/DefaultPermissionHandler.java
+++ b/src/main/java/net/minecraftforge/server/permission/DefaultPermissionHandler.java
@@ -84,7 +84,7 @@ public enum DefaultPermissionHandler implements IPermissionHandler
     }
 
     /**
-     * @return The default permission level of a node. If the permission isn't registred, it will return NONE
+     * @return The default permission level of a node. If the permission isn't registered, it will return NONE
      */
     public DefaultPermissionLevel getDefaultPermissionLevel(String node)
     {

--- a/src/main/java/net/minecraftforge/server/permission/IPermissionHandler.java
+++ b/src/main/java/net/minecraftforge/server/permission/IPermissionHandler.java
@@ -44,7 +44,7 @@ public interface IPermissionHandler
 
     /**
      * @param node Permission node
-     * @return Description of the node. "" in case this node doesn't have a decription
+     * @return Description of the node. "" in case this node doesn't have a description
      * @see #registerNode(String, DefaultPermissionLevel, String)
      */
     String getNodeDescription(String node);

--- a/src/main/java/net/minecraftforge/server/timings/ForgeTimings.java
+++ b/src/main/java/net/minecraftforge/server/timings/ForgeTimings.java
@@ -20,7 +20,6 @@
 package net.minecraftforge.server.timings;
 
 import java.lang.ref.WeakReference;
-import java.util.Arrays;
 
 /**
  * ForgeTimings aggregates timings data collected by {@link TimeTracker} for an Object

--- a/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
@@ -20,8 +20,6 @@
 package net.minecraftforge.debug.client.rendering;
 
 import net.minecraft.client.Minecraft;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;


### PR DESCRIPTION
There's a ton of affected files, trying to keep this one as simple as possible because of it.  I can add more invasive changes as a separate PR, or keep committing within this one if it'd not get too obnoxious.

For impacts with a code-level result, rather than purely comment or jdoc aspects: 
*  Variable names inside ICapabilityProvider and Capability provider's getCapability were set from `cap, side` to `capability, facing`, to match the jdocs.
*  RegistryObject.java, FMLHandshakeHandler.java, FMLLoginWrapper.java, LibraryManager.java, ForgeRegistry.java, ForgeConfigSpec.java have corrections to strings being fed to exceptions or the logger.