### PR TITLE
Update license headers to 2021

### DIFF
--- a/LICENSE-header.txt
+++ b/LICENSE-header.txt
@@ -1,5 +1,5 @@
 Minecraft Forge
-Copyright (c) 2016-2020.
+Copyright (c) 2016-2021.
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/CapabilityInjectDefinalize.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/ObjectHolderDefinalize.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/ObjectHolderDefinalize.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/AdvancedLogMessageAdapter.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/AdvancedLogMessageAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/BackgroundWaiter.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/BackgroundWaiter.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/EarlyLoadingException.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/EarlyLoadingException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLClientLaunchProvider.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLClientLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLCommonLaunchHandler.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLCommonLaunchHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLConfig.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLConfig.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLEnvironment.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLEnvironment.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLLoader.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLPaths.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLPaths.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLServerLaunchProvider.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLServerLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLServiceProvider.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLServiceProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FileUtils.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FileUtils.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FixSSL.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FixSSL.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/JarVersionLookupHandler.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/JarVersionLookupHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/Java9BackportUtils.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/Java9BackportUtils.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/LanguageLoadingProvider.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/LanguageLoadingProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/LauncherVersion.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/LauncherVersion.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/LibraryFinder.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/LibraryFinder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/LoadingModList.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/LoadingModList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/LogMarkers.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/LogMarkers.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/MavenCoordinateResolver.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/MavenCoordinateResolver.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/ModJarURLHandler.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/ModJarURLHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/RuntimeDistCleaner.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/StringSubstitutor.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/StringSubstitutor.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/StringUtils.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/StringUtils.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/TracingPrintStream.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/TracingPrintStream.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/VersionSupportMatrix.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/VersionSupportMatrix.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/log4j/ForgeHighlight.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/log4j/ForgeHighlight.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileLocator.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileLocator.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/BackgroundScanHandler.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/BackgroundScanHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/CoreModFile.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/CoreModFile.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ExplodedDirectoryLocator.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ExplodedDirectoryLocator.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/InvalidModFileException.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/InvalidModFileException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/InvalidModIdentifier.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/InvalidModIdentifier.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/MavenDirectoryLocator.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/MavenDirectoryLocator.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModAnnotation.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModAnnotation.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModAnnotationVisitor.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModAnnotationVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModClassVisitor.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModClassVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModDiscoverer.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModDiscoverer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFieldVisitor.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFieldVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileParser.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileParser.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModListHandler.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModListHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModMethodVisitor.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModMethodVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModsFolderLocator.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModsFolderLocator.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/NightConfigWrapper.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/NightConfigWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/EarlyProgressVisualization.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/StartupMessageManager.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/StartupMessageManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/CyclePresentException.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/CyclePresentException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/StronglyConnectedComponentDetector.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/StronglyConnectedComponentDetector.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/TopologicalSort.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/TopologicalSort.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllauncher/java/net/minecraftforge/server/ServerMain.java
+++ b/src/fmllauncher/java/net/minecraftforge/server/ServerMain.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/fmllaunchertest/java/net/minecraftforge/fml/test/TopologicalSortTests.java
+++ b/src/fmllaunchertest/java/net/minecraftforge/fml/test/TopologicalSortTests.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/CloudRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/CloudRenderHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/FluidContainerColorer.java
+++ b/src/main/java/net/minecraftforge/client/FluidContainerColorer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
+++ b/src/main/java/net/minecraftforge/client/ForgeRenderTypes.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/ForgeWorldTypeScreens.java
+++ b/src/main/java/net/minecraftforge/client/ForgeWorldTypeScreens.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/ICloudRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/ICloudRenderHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/IRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/IRenderHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/ISkyRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/ISkyRenderHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/IWeatherParticleRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/IWeatherParticleRenderHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/IWeatherRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/IWeatherRenderHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/ItemModelMesherForge.java
+++ b/src/main/java/net/minecraftforge/client/ItemModelMesherForge.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/SkyRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/SkyRenderHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/WeatherRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/WeatherRenderHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatReceivedEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameModeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerChangeGameModeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientPlayerNetworkEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ColorHandlerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ColorHandlerEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/DrawHighlightEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/DrawHighlightEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/FOVUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/FOVUpdateEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/GuiContainerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiContainerEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/GuiOpenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiOpenEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/InputUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputUpdateEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ModelBakeEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelBakeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ModelRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelRegistryEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ParticleFactoryRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ParticleFactoryRegisterEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RecipesUpdatedEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderBlockOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderBlockOverlayEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderHandEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemInFrameEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderNameplateEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlaySoundSourceEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/PlayStreamingSourceEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundLoadEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundLoadEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/event/sound/SoundSetupEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/sound/SoundSetupEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeBakedModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeKeybinding.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeKeybinding.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeModelTransform.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeModelTransform.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeRenderChunk.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeRenderChunk.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeTextureAtlasSprite.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeTextureAtlasSprite.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeTransformationMatrix.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeTransformationMatrix.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeUnbakedModel.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeUnbakedModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeVertexBuilder.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeVertexBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeIngameGui.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/gui/NotificationModUpdateScreen.java
+++ b/src/main/java/net/minecraftforge/client/gui/NotificationModUpdateScreen.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/BakedItemModel.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedItemModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/BakedModelWrapper.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedModelWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/BlockModelConfiguration.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockModelConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/CompositeModel.java
+++ b/src/main/java/net/minecraftforge/client/model/CompositeModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/DynamicBucketModel.java
+++ b/src/main/java/net/minecraftforge/client/model/DynamicBucketModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/FluidModel.java
+++ b/src/main/java/net/minecraftforge/client/model/FluidModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/IModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/IModelConfiguration.java
+++ b/src/main/java/net/minecraftforge/client/model/IModelConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/IModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/IModelLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/ItemMultiLayerBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemMultiLayerBakedModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/ModelDataManager.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDataManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/ModelLoadingException.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoadingException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/ModelTransformComposition.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelTransformComposition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/PerspectiveMapWrapper.java
+++ b/src/main/java/net/minecraftforge/client/model/PerspectiveMapWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/QuadTransformer.java
+++ b/src/main/java/net/minecraftforge/client/model/QuadTransformer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/SeparatePerspectiveModel.java
+++ b/src/main/java/net/minecraftforge/client/model/SeparatePerspectiveModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/SimpleModelTransform.java
+++ b/src/main/java/net/minecraftforge/client/model/SimpleModelTransform.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/animation/Animation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/Animation.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/animation/AnimationItemOverrideList.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/AnimationItemOverrideList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/animation/TileEntityRendererAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/TileEntityRendererAnimation.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/animation/package-info.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DClip.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DClip.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/b3d/package-info.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/data/EmptyModelData.java
+++ b/src/main/java/net/minecraftforge/client/model/data/EmptyModelData.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/data/IDynamicBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/model/data/IDynamicBakedModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/data/IModelData.java
+++ b/src/main/java/net/minecraftforge/client/model/data/IModelData.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/data/ModelDataMap.java
+++ b/src/main/java/net/minecraftforge/client/model/data/ModelDataMap.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/data/ModelProperty.java
+++ b/src/main/java/net/minecraftforge/client/model/data/ModelProperty.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockModelProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/BlockStateProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/ConfiguredModel.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ConfiguredModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/CustomLoaderBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/CustomLoaderBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/IGeneratedBlockstate.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/IGeneratedBlockstate.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/ItemModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ItemModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/ItemModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ItemModelProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelFile.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelFile.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/MultiPartBlockStateBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/VariantBlockStateBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/VariantBlockStateBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/CompositeModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/CompositeModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/DynamicBucketModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/DynamicBucketModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayersModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/ItemLayersModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/MultiLayerModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/MultiLayerModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/OBJLoaderBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/OBJLoaderBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/generators/loaders/SeparatePerspectiveModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/loaders/SeparatePerspectiveModelBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/geometry/IModelGeometry.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/IModelGeometry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/geometry/IModelGeometryPart.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/IModelGeometryPart.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/geometry/IMultipartModelGeometry.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/IMultipartModelGeometry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/geometry/ISimpleModelGeometry.java
+++ b/src/main/java/net/minecraftforge/client/model/geometry/ISimpleModelGeometry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/obj/LineReader.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/LineReader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/obj/MaterialLibrary.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/MaterialLibrary.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/obj/package-info.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/package-info.java
+++ b/src/main/java/net/minecraftforge/client/model/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/BakedQuadBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BakedQuadBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/IVertexConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/IVertexConsumer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/IVertexProducer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/IVertexProducer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/QuadGatheringTransformer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/QuadGatheringTransformer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/TRSRTransformer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/TRSRTransformer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/TransformerConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/TransformerConsumer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexBufferConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexBufferConsumer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexTransformer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexTransformer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/model/pipeline/package-info.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/settings/IKeyConflictContext.java
+++ b/src/main/java/net/minecraftforge/client/settings/IKeyConflictContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/settings/KeyConflictContext.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyConflictContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/AdvancementLoadFix.java
+++ b/src/main/java/net/minecraftforge/common/AdvancementLoadFix.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/BasicTrade.java
+++ b/src/main/java/net/minecraftforge/common/BasicTrade.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/DungeonHooks.java
+++ b/src/main/java/net/minecraftforge/common/DungeonHooks.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/FarmlandWaterManager.java
+++ b/src/main/java/net/minecraftforge/common/FarmlandWaterManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ForgeTagHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeTagHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
+++ b/src/main/java/net/minecraftforge/common/IExtensibleEnum.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/IForgeShearable.java
+++ b/src/main/java/net/minecraftforge/common/IForgeShearable.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/IMinecartCollisionHandler.java
+++ b/src/main/java/net/minecraftforge/common/IMinecartCollisionHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/IPlantable.java
+++ b/src/main/java/net/minecraftforge/common/IPlantable.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/PlantType.java
+++ b/src/main/java/net/minecraftforge/common/PlantType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ToolType.java
+++ b/src/main/java/net/minecraftforge/common/ToolType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/UsernameCache.java
+++ b/src/main/java/net/minecraftforge/common/UsernameCache.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/VillagerTradingManager.java
+++ b/src/main/java/net/minecraftforge/common/VillagerTradingManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/WorldWorkerManager.java
+++ b/src/main/java/net/minecraftforge/common/WorldWorkerManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/animation/Event.java
+++ b/src/main/java/net/minecraftforge/common/animation/Event.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/animation/IEventHandler.java
+++ b/src/main/java/net/minecraftforge/common/animation/IEventHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/animation/ITimeValue.java
+++ b/src/main/java/net/minecraftforge/common/animation/ITimeValue.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/animation/TimeValues.java
+++ b/src/main/java/net/minecraftforge/common/animation/TimeValues.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/brewing/BrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingRecipe.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/brewing/IBrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/IBrewingRecipe.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/brewing/VanillaBrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/VanillaBrewingRecipe.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/brewing/package-info.java
+++ b/src/main/java/net/minecraftforge/common/brewing/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityInject.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityInject.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilitySerializable.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilitySerializable.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/command/EntitySelectorManager.java
+++ b/src/main/java/net/minecraftforge/common/command/EntitySelectorManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/command/IEntitySelectorType.java
+++ b/src/main/java/net/minecraftforge/common/command/IEntitySelectorType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/ConditionalAdvancement.java
+++ b/src/main/java/net/minecraftforge/common/crafting/ConditionalAdvancement.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/ConditionalRecipe.java
+++ b/src/main/java/net/minecraftforge/common/crafting/ConditionalRecipe.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/IIngredientSerializer.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IIngredientSerializer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/IRecipeContainer.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IRecipeContainer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/IShapedRecipe.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IShapedRecipe.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/NBTIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/NBTIngredient.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/StackList.java
+++ b/src/main/java/net/minecraftforge/common/crafting/StackList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/VanillaIngredientSerializer.java
+++ b/src/main/java/net/minecraftforge/common/crafting/VanillaIngredientSerializer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/AndCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/AndCondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/FalseCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/FalseCondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/ICondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/ICondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/IConditionBuilder.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/IConditionBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/IConditionSerializer.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/IConditionSerializer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/ItemExistsCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/ItemExistsCondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/ModLoadedCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/ModLoadedCondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/NotCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/NotCondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/OrCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/OrCondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/TagEmptyCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/TagEmptyCondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/conditions/TrueCondition.java
+++ b/src/main/java/net/minecraftforge/common/crafting/conditions/TrueCondition.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/crafting/package-info.java
+++ b/src/main/java/net/minecraftforge/common/crafting/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
+++ b/src/main/java/net/minecraftforge/common/data/ExistingFileHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeBlockTagsProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/ForgeFluidTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeFluidTagsProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeLootTableProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/ForgeRecipeProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeRecipeProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/ForgeRegistryTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeRegistryTagsProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/GlobalLootModifierProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/GlobalLootModifierProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/data/LanguageProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/LanguageProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IAbstractRailBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IAbstractRailBlock.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeChunk.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeChunk.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeContainerType.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeContainerType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEffect.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEffect.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEffectInstance.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEffectInstance.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntityMinecart.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntityMinecart.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFluid.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFluid.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFluidState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFluidState.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgePacketBuffer.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgePacketBuffer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeResourcePack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeResourcePack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeSelectionContext.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeSelectionContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeStructure.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeStructure.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTagBuilder.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTagBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTagCollectionSupplier.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTagCollectionSupplier.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeWorld.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeWorld.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeWorldServer.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeWorldServer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/loot/GlobalLootModifierSerializer.java
+++ b/src/main/java/net/minecraftforge/common/loot/GlobalLootModifierSerializer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/loot/IGlobalLootModifier.java
+++ b/src/main/java/net/minecraftforge/common/loot/IGlobalLootModifier.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/loot/LootModifier.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootModifier.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootModifierManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/HiddenModelPart.java
+++ b/src/main/java/net/minecraftforge/common/model/HiddenModelPart.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/Models.java
+++ b/src/main/java/net/minecraftforge/common/model/Models.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/TransformationHelper.java
+++ b/src/main/java/net/minecraftforge/common/model/TransformationHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/animation/Clips.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/Clips.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/animation/IAnimationStateMachine.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/IAnimationStateMachine.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/animation/IClip.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/IClip.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/animation/IJoint.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/IJoint.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/animation/IJointClip.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/IJointClip.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/model/animation/JointClips.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/JointClips.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/property/Properties.java
+++ b/src/main/java/net/minecraftforge/common/property/Properties.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ticket/AABBTicket.java
+++ b/src/main/java/net/minecraftforge/common/ticket/AABBTicket.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ticket/ChunkTicketManager.java
+++ b/src/main/java/net/minecraftforge/common/ticket/ChunkTicketManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ticket/ITicketGetter.java
+++ b/src/main/java/net/minecraftforge/common/ticket/ITicketGetter.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ticket/ITicketManager.java
+++ b/src/main/java/net/minecraftforge/common/ticket/ITicketManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/ticket/SimpleTicket.java
+++ b/src/main/java/net/minecraftforge/common/ticket/SimpleTicket.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/BlockSnapshot.java
+++ b/src/main/java/net/minecraftforge/common/util/BlockSnapshot.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/ChunkCoordComparator.java
+++ b/src/main/java/net/minecraftforge/common/util/ChunkCoordComparator.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/Constants.java
+++ b/src/main/java/net/minecraftforge/common/util/Constants.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/DummyWorldSaveData.java
+++ b/src/main/java/net/minecraftforge/common/util/DummyWorldSaveData.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/FakePlayer.java
+++ b/src/main/java/net/minecraftforge/common/util/FakePlayer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/FakePlayerFactory.java
+++ b/src/main/java/net/minecraftforge/common/util/FakePlayerFactory.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/ForgeSoundType.java
+++ b/src/main/java/net/minecraftforge/common/util/ForgeSoundType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/HexDumper.java
+++ b/src/main/java/net/minecraftforge/common/util/HexDumper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/INBTSerializable.java
+++ b/src/main/java/net/minecraftforge/common/util/INBTSerializable.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/JsonUtils.java
+++ b/src/main/java/net/minecraftforge/common/util/JsonUtils.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/Lazy.java
+++ b/src/main/java/net/minecraftforge/common/util/Lazy.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/LazyOptional.java
+++ b/src/main/java/net/minecraftforge/common/util/LazyOptional.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/NonNullConsumer.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullConsumer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/NonNullFunction.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullFunction.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/NonNullLazy.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullLazy.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/NonNullPredicate.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullPredicate.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/NonNullSupplier.java
+++ b/src/main/java/net/minecraftforge/common/util/NonNullSupplier.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/RecipeMatcher.java
+++ b/src/main/java/net/minecraftforge/common/util/RecipeMatcher.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/ReverseTagWrapper.java
+++ b/src/main/java/net/minecraftforge/common/util/ReverseTagWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/Size2i.java
+++ b/src/main/java/net/minecraftforge/common/util/Size2i.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/SortedProperties.java
+++ b/src/main/java/net/minecraftforge/common/util/SortedProperties.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/TextTable.java
+++ b/src/main/java/net/minecraftforge/common/util/TextTable.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/TriPredicate.java
+++ b/src/main/java/net/minecraftforge/common/util/TriPredicate.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/util/WorldCapabilityData.java
+++ b/src/main/java/net/minecraftforge/common/util/WorldCapabilityData.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/world/BiomeGenerationSettingsBuilder.java
+++ b/src/main/java/net/minecraftforge/common/world/BiomeGenerationSettingsBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/world/ForgeWorldType.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeWorldType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/world/MobSpawnInfoBuilder.java
+++ b/src/main/java/net/minecraftforge/common/world/MobSpawnInfoBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/common/world/StructureSpawnManager.java
+++ b/src/main/java/net/minecraftforge/common/world/StructureSpawnManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
+++ b/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/energy/EnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/EnergyStorage.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
+++ b/src/main/java/net/minecraftforge/event/AddReloadListenerEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/CommandEvent.java
+++ b/src/main/java/net/minecraftforge/event/CommandEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/minecraftforge/event/ItemAttributeModifierEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,6 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
 package net.minecraftforge.event;
 
 import com.google.common.collect.HashMultimap;

--- a/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegisterCommandsEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/RegistryEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegistryEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/ServerChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/ServerChatEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/minecraftforge/event/TagsUpdatedEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/TickEvent.java
+++ b/src/main/java/net/minecraftforge/event/TickEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PlayerBrewedPotionEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
+++ b/src/main/java/net/minecraftforge/event/brewing/PotionBrewEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
+++ b/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/EntityJoinWorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityJoinWorldEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/EntityLeaveWorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityLeaveWorldEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityStruckByLightningEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/EnderTeleportEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/EnderTeleportEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingConversionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingConversionEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDeathEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDestroyBlockEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEquipmentChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEquipmentChangeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingFallEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHealEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingHurtEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingPackSizeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSetAttackTargetEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSetAttackTargetEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/PotionColorCalculationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/PotionColorCalculationEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/PotionEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/ZombieEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AdvancementEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowLooseEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArrowNockEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/EntityItemPickupEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerContainerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerContainerEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerFlyableFallEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerFlyableFallEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSetSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSetSpawnEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSleepInBedEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingLocationCheckEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/entity/player/UseHoeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/UseHoeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/furnace/FurnaceFuelBurnTimeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/village/VillagerTradesEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillagerTradesEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/WandererTradesEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/BiomeLoadingEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BiomeLoadingEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkDataEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/ExplosionEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ExplosionEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/NoteBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/NoteBlockEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/RegisterDimensionsEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/RegisterDimensionsEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/SaplingGrowTreeEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/SaplingGrowTreeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/SleepFinishedTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/SleepFinishedTimeEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/StructureSpawnListGatherEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/StructureSpawnListGatherEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/event/world/WorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WorldEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/DispenseFluidContainer.java
+++ b/src/main/java/net/minecraftforge/fluids/DispenseFluidContainer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/FluidActionResult.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidActionResult.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidAttributes.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/ForgeFlowingFluid.java
+++ b/src/main/java/net/minecraftforge/fluids/ForgeFlowingFluid.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
+++ b/src/main/java/net/minecraftforge/fluids/IFluidBlock.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/IFluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/IFluidTank.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/CapabilityFluidHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandlerItem.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandlerItem.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/ItemFluidContainer.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/ItemFluidContainer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/EmptyFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/EmptyFluidHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/VoidFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/VoidFluidHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/BlockWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/BlockWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/AutomaticEventSubscriber.java
+++ b/src/main/java/net/minecraftforge/fml/AutomaticEventSubscriber.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/BrandingControl.java
+++ b/src/main/java/net/minecraftforge/fml/BrandingControl.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/CrashReportExtender.java
+++ b/src/main/java/net/minecraftforge/fml/CrashReportExtender.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/DatagenModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/DatagenModLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
+++ b/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/DistExecutor.java
+++ b/src/main/java/net/minecraftforge/fml/DistExecutor.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ExtensionPoint.java
+++ b/src/main/java/net/minecraftforge/fml/ExtensionPoint.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/FMLWorldPersistenceHook.java
+++ b/src/main/java/net/minecraftforge/fml/FMLWorldPersistenceHook.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ForgeI18n.java
+++ b/src/main/java/net/minecraftforge/fml/ForgeI18n.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/InterModComms.java
+++ b/src/main/java/net/minecraftforge/fml/InterModComms.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/LoadingFailedException.java
+++ b/src/main/java/net/minecraftforge/fml/LoadingFailedException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/Logging.java
+++ b/src/main/java/net/minecraftforge/fml/Logging.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/LogicalSide.java
+++ b/src/main/java/net/minecraftforge/fml/LogicalSide.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/LogicalSidedProvider.java
+++ b/src/main/java/net/minecraftforge/fml/LogicalSidedProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/MavenVersionStringHelper.java
+++ b/src/main/java/net/minecraftforge/fml/MavenVersionStringHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ModList.java
+++ b/src/main/java/net/minecraftforge/fml/ModList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ModLoadingException.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ModLoadingStage.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingStage.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ModLoadingWarning.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingWarning.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/ModWorkManager.java
+++ b/src/main/java/net/minecraftforge/fml/ModWorkManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/OptionalMod.java
+++ b/src/main/java/net/minecraftforge/fml/OptionalMod.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/fml/RegistryObject.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/StartupMessageManager.java
+++ b/src/main/java/net/minecraftforge/fml/StartupMessageManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/TextComponentMessageFormatHandler.java
+++ b/src/main/java/net/minecraftforge/fml/TextComponentMessageFormatHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/VersionChecker.java
+++ b/src/main/java/net/minecraftforge/fml/VersionChecker.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/WorldPersistenceHooks.java
+++ b/src/main/java/net/minecraftforge/fml/WorldPersistenceHooks.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/ConfigGuiHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/ConfigGuiHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/ExtendedServerListData.java
+++ b/src/main/java/net/minecraftforge/fml/client/ExtendedServerListData.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiUtils.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/screen/ConfirmationScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/screen/ConfirmationScreen.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/screen/LoadingErrorScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/screen/LoadingErrorScreen.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/screen/ModListScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/screen/ModListScreen.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/screen/NotificationScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/screen/NotificationScreen.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/widget/ExtendedButton.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/widget/ExtendedButton.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/widget/ModListWidget.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/widget/Slider.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/widget/Slider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/gui/widget/UnicodeGlyphButton.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/widget/UnicodeGlyphButton.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/registry/ClientRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/client/registry/ClientRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/registry/IRenderFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/registry/IRenderFactory.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/CertificateHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/CertificateHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/EnhancedRuntimeException.java
+++ b/src/main/java/net/minecraftforge/fml/common/EnhancedRuntimeException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/ICrashCallable.java
+++ b/src/main/java/net/minecraftforge/fml/common/ICrashCallable.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/LoaderException.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoaderException.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/LoaderExceptionModCrash.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoaderExceptionModCrash.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/network/ByteBufUtils.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/ByteBufUtils.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/network/PacketLoggingHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/PacketLoggingHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/registry/IEntityAdditionalSpawnData.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/IEntityAdditionalSpawnData.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/thread/EffectiveSide.java
+++ b/src/main/java/net/minecraftforge/fml/common/thread/EffectiveSide.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/thread/SidedThreadGroup.java
+++ b/src/main/java/net/minecraftforge/fml/common/thread/SidedThreadGroup.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/common/thread/SidedThreadGroups.java
+++ b/src/main/java/net/minecraftforge/fml/common/thread/SidedThreadGroups.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigFileTypeHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/config/ModConfig.java
+++ b/src/main/java/net/minecraftforge/fml/config/ModConfig.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLClientSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLClientSetupEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLCommonSetupEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLConstructModEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLConstructModEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLDedicatedServerSetupEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLFingerprintViolationEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLFingerprintViolationEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLLoadCompleteEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLLoadCompleteEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLModIdMappingEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/FMLModIdMappingEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/GatherDataEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/GatherDataEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/IModBusEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/IModBusEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModEnqueueEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModEnqueueEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/InterModProcessEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/ModLifecycleEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/lifecycle/ParallelDispatchEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/lifecycle/ParallelDispatchEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/server/FMLServerAboutToStartEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/server/FMLServerAboutToStartEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/server/FMLServerStartedEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/server/FMLServerStartedEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/server/FMLServerStartingEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/server/FMLServerStartingEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/server/FMLServerStoppedEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/server/FMLServerStoppedEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/server/FMLServerStoppingEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/server/FMLServerStoppingEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/event/server/ServerLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/fml/event/server/ServerLifecycleEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLanguageProvider.java
+++ b/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLanguageProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLoadingContext.java
+++ b/src/main/java/net/minecraftforge/fml/javafmlmod/FMLJavaModLoadingContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/mclanguageprovider/MinecraftModLanguageProvider.java
+++ b/src/main/java/net/minecraftforge/fml/mclanguageprovider/MinecraftModLanguageProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/ConnectionType.java
+++ b/src/main/java/net/minecraftforge/fml/network/ConnectionType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/FMLHandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLHandshakeHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/FMLHandshakeMessages.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLHandshakeMessages.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/FMLLoginWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLLoginWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/FMLMCRegisterPacketHandler.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLMCRegisterPacketHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/FMLNetworkConstants.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLNetworkConstants.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/FMLPlayMessages.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLPlayMessages.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/FMLStatusPing.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLStatusPing.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/IContainerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/network/IContainerFactory.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/ICustomPacket.java
+++ b/src/main/java/net/minecraftforge/fml/network/ICustomPacket.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/NetworkDirection.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkDirection.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/NetworkEvent.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkEvent.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/NetworkInitialization.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkInitialization.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/NetworkInstance.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkInstance.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/PacketDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/network/PacketDispatcher.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/PacketDistributor.java
+++ b/src/main/java/net/minecraftforge/fml/network/PacketDistributor.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/event/EventNetworkChannel.java
+++ b/src/main/java/net/minecraftforge/fml/network/event/EventNetworkChannel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/simple/IndexedMessageCodec.java
+++ b/src/main/java/net/minecraftforge/fml/network/simple/IndexedMessageCodec.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/network/simple/SimpleChannel.java
+++ b/src/main/java/net/minecraftforge/fml/network/simple/SimpleChannel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/packs/DelegatingResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/DelegatingResourcePack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/packs/ResourcePackLoader.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ResourcePackLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/Artifact.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/Artifact.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/LinkRepository.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/LinkRepository.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/MemoryModList.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/MemoryModList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/ModList.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/ModList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/Repository.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/Repository.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/SnapshotJson.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/SnapshotJson.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/server/LanguageHook.java
+++ b/src/main/java/net/minecraftforge/fml/server/LanguageHook.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/server/ServerModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/server/ServerModLoader.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/fml/util/ThreeConsumer.java
+++ b/src/main/java/net/minecraftforge/fml/util/ThreeConsumer.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/IItemHandlerModifiable.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandlerModifiable.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/SlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/SlotItemHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/VanillaHopperItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/VanillaHopperItemHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/EmptyHandler.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EmptyHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityArmorInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityArmorInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityHandsInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityHandsInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerArmorInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerArmorInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerMainInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerMainInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerOffhandInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerOffhandInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/RecipeWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RecipeWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/logging/ModelLoaderErrorMessage.java
+++ b/src/main/java/net/minecraftforge/logging/ModelLoaderErrorMessage.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/network/CommandTreeCleaner.java
+++ b/src/main/java/net/minecraftforge/network/CommandTreeCleaner.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/network/VanillaConnectionNetworkFilter.java
+++ b/src/main/java/net/minecraftforge/network/VanillaConnectionNetworkFilter.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/DataSerializerEntry.java
+++ b/src/main/java/net/minecraftforge/registries/DataSerializerEntry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistryEntry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistryInternal.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistryInternal.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistryModifiable.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistryModifiable.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/ILockableRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ILockableRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/IRegistryDelegate.java
+++ b/src/main/java/net/minecraftforge/registries/IRegistryDelegate.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/ObjectHolder.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/RegistryDelegate.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryDelegate.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/resource/IResourceType.java
+++ b/src/main/java/net/minecraftforge/resource/IResourceType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/resource/ISelectiveResourceReloadListener.java
+++ b/src/main/java/net/minecraftforge/resource/ISelectiveResourceReloadListener.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/resource/ReloadRequirements.java
+++ b/src/main/java/net/minecraftforge/resource/ReloadRequirements.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/resource/SelectiveReloadStateHandler.java
+++ b/src/main/java/net/minecraftforge/resource/SelectiveReloadStateHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/resource/VanillaResourceType.java
+++ b/src/main/java/net/minecraftforge/resource/VanillaResourceType.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/resource/package-info.java
+++ b/src/main/java/net/minecraftforge/resource/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/ChunkGenWorker.java
+++ b/src/main/java/net/minecraftforge/server/command/ChunkGenWorker.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/CommandDimensions.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandDimensions.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/CommandEntity.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandEntity.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/CommandGenerate.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandGenerate.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/CommandModList.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandModList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/CommandTps.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandTps.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/CommandTrack.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandTrack.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/ConfigCommand.java
+++ b/src/main/java/net/minecraftforge/server/command/ConfigCommand.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/EnumArgument.java
+++ b/src/main/java/net/minecraftforge/server/command/EnumArgument.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/ForgeCommand.java
+++ b/src/main/java/net/minecraftforge/server/command/ForgeCommand.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/ModIdArgument.java
+++ b/src/main/java/net/minecraftforge/server/command/ModIdArgument.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/TextComponentHelper.java
+++ b/src/main/java/net/minecraftforge/server/command/TextComponentHelper.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/command/package-info.java
+++ b/src/main/java/net/minecraftforge/server/command/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/console/ConsoleCommandCompleter.java
+++ b/src/main/java/net/minecraftforge/server/console/ConsoleCommandCompleter.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/console/TerminalHandler.java
+++ b/src/main/java/net/minecraftforge/server/console/TerminalHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/DefaultPermissionHandler.java
+++ b/src/main/java/net/minecraftforge/server/permission/DefaultPermissionHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/DefaultPermissionLevel.java
+++ b/src/main/java/net/minecraftforge/server/permission/DefaultPermissionLevel.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/IPermissionHandler.java
+++ b/src/main/java/net/minecraftforge/server/permission/IPermissionHandler.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/AreaContext.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/AreaContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/BlockPosContext.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/BlockPosContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/Context.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/Context.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/ContextKey.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/ContextKey.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/ContextKeys.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/ContextKeys.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/IContext.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/IContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/PlayerContext.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/PlayerContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/TargetContext.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/TargetContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/WorldContext.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/WorldContext.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/context/package-info.java
+++ b/src/main/java/net/minecraftforge/server/permission/context/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/permission/package-info.java
+++ b/src/main/java/net/minecraftforge/server/permission/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/timings/ForgeTimings.java
+++ b/src/main/java/net/minecraftforge/server/timings/ForgeTimings.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/server/timings/TimeTracker.java
+++ b/src/main/java/net/minecraftforge/server/timings/TimeTracker.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/versions/forge/ForgeVersion.java
+++ b/src/main/java/net/minecraftforge/versions/forge/ForgeVersion.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/net/minecraftforge/versions/mcp/MCPVersion.java
+++ b/src/main/java/net/minecraftforge/versions/mcp/MCPVersion.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/CodecsTest.java
+++ b/src/test/java/net/minecraftforge/debug/CodecsTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/CustomSoundTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/CustomSoundTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/DataGeneratorTest.java
+++ b/src/test/java/net/minecraftforge/debug/DataGeneratorTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/DeferredRegistryTest.java
+++ b/src/test/java/net/minecraftforge/debug/DeferredRegistryTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/PotionEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/PotionEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/BasePlaceEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/BasePlaceEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/CustomPlantTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/CustomPlantTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/FarmlandTrampleEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/FarmlandTrampleEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/FlowerPotTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/FlowerPotTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/HarvestToolTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/HarvestToolTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/NeighborNotifyEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/NeighborNotifyEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/PlaceEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PlaceEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/ScaffoldingTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/ScaffoldingTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/SlipperinessTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/SlipperinessTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/StickyBlockTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/StickyBlockTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/ToolInteractTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/ToolInteractTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/block/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/block/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/chat/ClientChatEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chat/ClientChatEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/chat/CommandEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/chat/CommandEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/chat/EntitySelectorTest.java
+++ b/src/test/java/net/minecraftforge/debug/chat/EntitySelectorTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/chat/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/chat/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/model/CompositeModelTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/CompositeModelTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/model/MultiLayerModelTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/MultiLayerModelTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/model/TRSRTransformerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/TRSRTransformerTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/model/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/rendering/NameplateRenderingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/NameplateRenderingEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/rendering/RenderLocalPlayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/RenderLocalPlayerTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/StencilEnableTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/client/rendering/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/CreateEntityClassificationTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/CreateEntityClassificationTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/GravityAttributeTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/GravityAttributeTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/living/LivingConversionEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/LivingConversionEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/entity/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerGameModeEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerGameModeEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerNameEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerNameEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerXpEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerXpEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/player/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/fluid/FiniteWaterTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/FiniteWaterTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/fluid/MilkFluidTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/MilkFluidTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/fluid/NewFluidTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/NewFluidTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/fluid/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/GlobalLootModifiersTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/gameplay/loot/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/loot/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/item/CustomElytraTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomElytraTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/item/EnderMaskTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/EnderMaskTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/item/ItemAttributeModifierTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ItemAttributeModifierTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,6 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.entity.ai.attributes.AttributeModifier;

--- a/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/MusicDiscTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/item/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/item/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/misc/ContainerTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/ContainerTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/misc/CustomTagTypesTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/CustomTagTypesTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/misc/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/misc/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/BiomeLoadingEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/world/ChunkDataEventSaveNullWorldTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkDataEventSaveNullWorldTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/world/ChunkWatchEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkWatchEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/world/ForgeWorldTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ForgeWorldTypeTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/world/RaidEnumTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/RaidEnumTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/world/StructureSpawnListGatherEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/StructureSpawnListGatherEventTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/world/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/world/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/test/TextTableTest.java
+++ b/src/test/java/net/minecraftforge/test/TextTableTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/ArgumentList.java
+++ b/src/userdev/java/net/minecraftforge/userdev/ArgumentList.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/ClasspathLocator.java
+++ b/src/userdev/java/net/minecraftforge/userdev/ClasspathLocator.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/FMLDevClientLaunchProvider.java
+++ b/src/userdev/java/net/minecraftforge/userdev/FMLDevClientLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/FMLDevDataLaunchProvider.java
+++ b/src/userdev/java/net/minecraftforge/userdev/FMLDevDataLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/FMLDevServerLaunchProvider.java
+++ b/src/userdev/java/net/minecraftforge/userdev/FMLDevServerLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/FMLUserdevClientLaunchProvider.java
+++ b/src/userdev/java/net/minecraftforge/userdev/FMLUserdevClientLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/FMLUserdevDataLaunchProvider.java
+++ b/src/userdev/java/net/minecraftforge/userdev/FMLUserdevDataLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/FMLUserdevLaunchProvider.java
+++ b/src/userdev/java/net/minecraftforge/userdev/FMLUserdevLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/FMLUserdevServerLaunchProvider.java
+++ b/src/userdev/java/net/minecraftforge/userdev/FMLUserdevServerLaunchProvider.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/LaunchTesting.java
+++ b/src/userdev/java/net/minecraftforge/userdev/LaunchTesting.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/userdev/java/net/minecraftforge/userdev/MCPNamingService.java
+++ b/src/userdev/java/net/minecraftforge/userdev/MCPNamingService.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2020.
+ * Copyright (c) 2016-2021.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
Updates the license headers to match the current year, 2021. _<sup>or as some would say, 2020++</sup>_