### PR TITLE
Add or improve javadocs across the Forge codebase

### DIFF
--- a/src/main/java/net/minecraftforge/fml/LogicalSide.java
+++ b/src/main/java/net/minecraftforge/fml/LogicalSide.java
@@ -19,12 +19,66 @@
 
 package net.minecraftforge.fml;
 
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.api.distmarker.Dist;
+
+/**
+ * A logical side of the Minecraft game.
+ * <p>
+ * There are two logical sides within the game:
+ * <ul>
+ *     <li>{@link #CLIENT} is the logical <em>client</em>, which is controlled by the player. It processes inputs to be
+ *     sent over to the server, renders the viewport of the game, and maintains a copy of the world as dictated by the
+ *     server's copy. </li>
+ *     <li>{@link #SERVER} is the logical <em>server</em>, which runs seperately from the logical client. It listens
+ *     for and establishes connections from logical clients, handles the game logic for the world, and maintains the
+ *     authoritative copy of the world. </li>
+ * </ul>
+ * <p>
+ * The {@linkplain Dist#CLIENT client distribution} has a copy of both the logical
+ * server and the logical client, while the {@linkplain Dist#DEDICATED_SERVER
+ * dedicated server distribution}, as its name implies, only holds the logical server.
+ *
+ * @see Dist
+ * @see LogicalSidedProvider
+ * @see World#isRemote
+ */
 public enum LogicalSide
 {
-    CLIENT, SERVER;
+    /**
+     * The logical client of the Minecraft game.
+     * <p>
+     * This is the side responsible for translating player inputs to entity movement and interaction, rendering the
+     * viewport for the player, and storing the local client copy of the world as dictated by the server's
+     * authoritative copy of the world.
+     * <p>
+     * The logical client is only shipped with the client distribution of the game.
+     *
+     * @see ClientWorld
+     * @see Dist#CLIENT
+     */
+    CLIENT,
+    /**
+     * The logical server of the Minecraft game.
+     * <p>
+     * This is the side responsible for managing connections to logical clients, maintaining the authoritative copy of
+     * the game world, and running the game simulation logic on the world.
+     * <p>
+     * The logical server comes with both the client distribution and the dedicated server distribution. The client
+     * distribution runs the logical server for the "Singleplayer" mode, wherein the client both holds the logical
+     * client and the logical server.
+     *
+     * @see ServerWorld
+     * @see Dist#DEDICATED_SERVER
+     */
+    SERVER;
 
     /**
-     * @return if the logical side is a server.
+     * Returns if this logical side is a server.
+     *
+     * @return if this is the server side
      */
     public boolean isServer()
     {
@@ -32,7 +86,9 @@ public enum LogicalSide
     }
 
     /**
-     * @return if the logical side is a client.
+     * Returns if this logical side is a client.
+     *
+     * @return if this is the client side
      */
     public boolean isClient()
     {


### PR DESCRIPTION
This PR aims to add or improve the javadocs across the Forge codebase.

The general aim is to improve the quality of the javadocs, remove outdated references and/or information, improve the readability, add more information, and try to create a pseudo-standard for javadocs. 
This author hopes that it may one day be possible to run the javadoc tool across the Forge codebase and produce consistent, readable, and informative javadocs for all Forge classes.

**Note:** I have yet to figure out how to document patched-in Forge methods to classes and methods, due to the side-effect that javadocs for those files will inflate the patch files. A possible solution would be to implement extension interfaces everywhere and use `{@inheritDoc}`, but I feel that would be too invasive. Anyone who has a solution, please contact me at The Forge Project discord.