### PR TITLE
Deprecation Javadoc Improvements

### DIFF
--- a/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AbstractBlock.java.patch
@@ -52,7 +52,7 @@
        return 0;
     }
  
-+   @Deprecated // Forge: Use state.hasTileEntity()
++   /**@deprecated Use {@link BlockState#hasTileEntity()}*/@Deprecated
     public final boolean func_235695_q_() {
        return this instanceof ITileEntityProvider;
     }
@@ -80,12 +80,11 @@
     public abstract static class AbstractBlockState extends StateHolder<Block, BlockState> {
        private final int field_215708_d;
        private final boolean field_215709_e;
-@@ -428,14 +439,18 @@
+@@ -428,14 +439,16 @@
           return this.field_215708_d;
        }
  
-+      /** @deprecated use {@link BlockState#isAir(IBlockReader, BlockPos) */
-+      @Deprecated
++      /**@deprecated Use {@link BlockState#isAir(IBlockReader, BlockPos)*/@Deprecated
        public boolean func_196958_f() {
 -         return this.field_235702_f_;
 +         return this.func_177230_c().isAir((BlockState)this);
@@ -95,12 +94,11 @@
           return this.field_235704_h_;
        }
  
-+      /** @deprecated use {@link BlockState#rotate(IWorld, BlockPos, Rotation) */
-+      @Deprecated
++      /**@deprecated Use {@link BlockState#rotate(IWorld, BlockPos, Rotation)*/@Deprecated
        public BlockState func_185907_a(Rotation p_185907_1_) {
           return this.func_177230_c().func_185499_a(this.func_230340_p_(), p_185907_1_);
        }
-@@ -802,6 +817,9 @@
+@@ -802,6 +815,9 @@
        private ResourceLocation field_222381_j;
        private boolean field_226895_m_ = true;
        private boolean field_235813_o_;
@@ -110,7 +108,7 @@
        private AbstractBlock.IExtendedPositionPredicate<EntityType<?>> field_235814_p_ = (p_235832_0_, p_235832_1_, p_235832_2_, p_235832_3_) -> {
           return p_235832_0_.func_224755_d(p_235832_1_, p_235832_2_, Direction.UP) && p_235832_0_.func_185906_d() < 14;
        };
-@@ -863,6 +881,8 @@
+@@ -863,6 +879,8 @@
           abstractblock$properties.field_226895_m_ = p_200950_0_.field_235684_aB_.field_226895_m_;
           abstractblock$properties.field_235813_o_ = p_200950_0_.field_235684_aB_.field_235813_o_;
           abstractblock$properties.field_235806_h_ = p_200950_0_.field_235684_aB_.field_235806_h_;
@@ -119,7 +117,7 @@
           return abstractblock$properties;
        }
  
-@@ -877,6 +897,24 @@
+@@ -877,6 +895,24 @@
           return this;
        }
  
@@ -144,7 +142,7 @@
        public AbstractBlock.Properties func_200941_a(float p_200941_1_) {
           this.field_200961_i = p_200941_1_;
           return this;
-@@ -932,11 +970,17 @@
+@@ -932,11 +968,17 @@
           return this;
        }
  

--- a/patches/minecraft/net/minecraft/block/AbstractRailBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/AbstractRailBlock.java.patch
@@ -39,7 +39,7 @@
        return blockstate.func_206870_a(this.func_176560_l(), flag ? RailShape.EAST_WEST : RailShape.NORTH_SOUTH);
     }
  
-+   @Deprecated // Forge: Use getRailDirection(IBlockAccess, BlockPos, IBlockState, EntityMinecart) for enhanced ability
++   /**@deprecated Use {@link AbstractRailBlock#getRailDirection(BlockState, IBlockReader, BlockPos, net.minecraft.entity.item.minecart.AbstractMinecartEntity)}*/@Deprecated
     public abstract Property<RailShape> func_176560_l();
 +
 +   // Forge Start

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -8,7 +8,7 @@
 +public class Block extends AbstractBlock implements IItemProvider, net.minecraftforge.common.extensions.IForgeBlock {
     protected static final Logger field_196273_d = LogManager.getLogger();
 -   public static final ObjectIntIdentityMap<BlockState> field_176229_d = new ObjectIntIdentityMap<>();
-+   @Deprecated // Forge: Do not use, use GameRegistry
++   /**@deprecated Use {@link net.minecraftforge.fml.common.registry.GameRegistry}*/@Deprecated
 +   public static final ObjectIntIdentityMap<BlockState> field_176229_d = net.minecraftforge.registries.GameData.getBlockStateIDMap();
     private static final LoadingCache<VoxelShape, Boolean> field_223006_b = CacheBuilder.newBuilder().maximumSize(512L).weakKeys().build(new CacheLoader<VoxelShape, Boolean>() {
        public Boolean load(VoxelShape p_load_1_) {
@@ -44,7 +44,7 @@
  
     }
  
-+   @Deprecated // Forge: Use more sensitive version
++   /**@deprecated Use more sensitive version {@link Block#getExplosionResistance(BlockState, IBlockReader, BlockPos, Explosion)}*/@Deprecated
     public float func_149638_a() {
        return this.field_235689_au_;
     }
@@ -52,7 +52,7 @@
        p_176216_2_.func_213317_d(p_176216_2_.func_213322_ci().func_216372_d(1.0D, 0.0D, 1.0D));
     }
  
-+   @Deprecated // Forge: Use more sensitive version
++   /**@deprecated Use more sensitive version {@link Block#asItem}.*/@Deprecated 
     public ItemStack func_185473_a(IBlockReader p_185473_1_, BlockPos p_185473_2_, BlockState p_185473_3_) {
        return new ItemStack(this);
     }
@@ -60,7 +60,7 @@
     public void func_176224_k(World p_176224_1_, BlockPos p_176224_2_) {
     }
  
-+   @Deprecated // Forge: Use more sensitive version
++   /**@deprecated Use more sensitive version {@link Block#canDropFromExplosion(BlockState, IBlockReader, BlockPos, Explosion)}*/@Deprecated
     public boolean func_149659_a(Explosion p_149659_1_) {
        return true;
     }
@@ -68,7 +68,7 @@
        return this.field_196275_y;
     }
  
-+   @Deprecated // Forge: Use more sensitive version {@link IForgeBlockState#getSoundType(IWorldReader, BlockPos, Entity) }
++   /**@deprecated Use more sensitive version {@link net.minecraftforge.common.extensions.IForgeBlockState#getSoundType(IWorldReader, BlockPos, Entity)}*/@Deprecated 
     public SoundType func_220072_p(BlockState p_220072_1_) {
        return this.field_149762_H;
     }

--- a/patches/minecraft/net/minecraft/block/FireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FireBlock.java.patch
@@ -57,12 +57,12 @@
        return p_176537_1_.func_175727_C(p_176537_2_) || p_176537_1_.func_175727_C(p_176537_2_.func_177976_e()) || p_176537_1_.func_175727_C(p_176537_2_.func_177974_f()) || p_176537_1_.func_175727_C(p_176537_2_.func_177978_c()) || p_176537_1_.func_175727_C(p_176537_2_.func_177968_d());
     }
  
-+   @Deprecated // Forge: Use IForgeBlockState.getFlammability, Public for default implementation only.
++   /**@deprecated Use {@link BlockState#getFlammability(IBlockReader, BlockPos, Direction)}. Public for default implementation only.*/@Deprecated
     public int func_220274_q(BlockState p_220274_1_) {
        return p_220274_1_.func_235901_b_(BlockStateProperties.field_208198_y) && p_220274_1_.func_177229_b(BlockStateProperties.field_208198_y) ? 0 : this.field_149848_b.getInt(p_220274_1_.func_177230_c());
     }
  
-+   @Deprecated // Forge: Use IForgeBlockState.getFireSpreadSpeed
++   /**@deprecated Use {@link BlockState#getFireSpreadSpeed(IBlockReader, BlockPos, Direction)}*/@Deprecated
     public int func_220275_r(BlockState p_220275_1_) {
        return p_220275_1_.func_235901_b_(BlockStateProperties.field_208198_y) && p_220275_1_.func_177229_b(BlockStateProperties.field_208198_y) ? 0 : this.field_149849_a.getInt(p_220275_1_.func_177230_c());
     }
@@ -108,7 +108,7 @@
        }
     }
  
-+   @Deprecated // Forge: Use canCatchFire with more context
++   /**@deprecated Use {@link FireBlock#canCatchFire(IBlockReader, BlockPos, Direction)}*/@Deprecated
     protected boolean func_196446_i(BlockState p_196446_1_) {
        return this.func_220275_r(p_196446_1_) > 0;
     }

--- a/patches/minecraft/net/minecraft/block/FlowerPotBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FlowerPotBlock.java.patch
@@ -4,7 +4,7 @@
     protected static final VoxelShape field_196450_a = Block.func_208617_a(5.0D, 0.0D, 5.0D, 11.0D, 6.0D, 11.0D);
     private final Block field_196452_c;
  
-+   @Deprecated // Forge: Mods should use the constructor below
++   /**@deprecated Mods should use {@link FlowerPotBlock#FlowerPotBlock(Supplier, Supplier, Properties)}*/@Deprecated
     public FlowerPotBlock(Block p_i48395_1_, AbstractBlock.Properties p_i48395_2_) {
 -      super(p_i48395_2_);
 -      this.field_196452_c = p_i48395_1_;

--- a/patches/minecraft/net/minecraft/block/FlowingFluidBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FlowingFluidBlock.java.patch
@@ -9,7 +9,7 @@
     private final List<FluidState> field_212565_c;
     public static final VoxelShape field_235510_c_ = Block.func_208617_a(0.0D, 0.0D, 0.0D, 16.0D, 8.0D, 16.0D);
  
-+   @Deprecated  // Forge: Use the constructor that takes a supplier
++   /**@deprecated Use {@link FlowingFluidBlock#FlowingFluidBlock(java.util.function.Supplier, Properties)}*/@Deprecated
     public FlowingFluidBlock(FlowingFluid p_i49014_1_, AbstractBlock.Properties p_i49014_2_) {
        super(p_i49014_2_);
        this.field_204517_c = p_i49014_1_;

--- a/patches/minecraft/net/minecraft/block/ITileEntityProvider.java.patch
+++ b/patches/minecraft/net/minecraft/block/ITileEntityProvider.java.patch
@@ -4,7 +4,7 @@
  import net.minecraft.tileentity.TileEntity;
  import net.minecraft.world.IBlockReader;
  
-+@Deprecated // Forge: Do not use, use BlockState.hasTileEntity/Block.createTileEntity
++/**@deprecated Use {@link BlockState#hasTileEntity()} and {@link Block#createTileEntity(BlockState, IBlockReader)}*/@Deprecated
  public interface ITileEntityProvider {
     @Nullable
     TileEntity func_196283_a_(IBlockReader p_196283_1_);

--- a/patches/minecraft/net/minecraft/block/StairsBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/StairsBlock.java.patch
@@ -4,7 +4,7 @@
        return voxelshape;
     }
  
-+   @Deprecated // Forge: Use the other constructor that takes a Supplier
++   /**@deprecated Use {@link StairsBlock#StairsBlock(java.util.function.Supplier, Properties)}*/@Deprecated
     public StairsBlock(BlockState p_i48321_1_, AbstractBlock.Properties p_i48321_2_) {
        super(p_i48321_2_);
        this.func_180632_j(this.field_176227_L.func_177621_b().func_206870_a(field_176309_a, Direction.NORTH).func_206870_a(field_176308_b, Half.BOTTOM).func_206870_a(field_176310_M, StairsShape.STRAIGHT).func_206870_a(field_204513_t, Boolean.valueOf(false)));

--- a/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TNTBlock.java.patch
@@ -38,12 +38,12 @@
        }
     }
  
-+   @Deprecated // Forge: Prefer using IForgeBlock#catchFire
++   /**@deprecated Prefer {@link BlockState#catchFire(World, BlockPos, net.minecraft.util.Direction, LivingEntity)}*/@Deprecated
     public static void func_196534_a(World p_196534_0_, BlockPos p_196534_1_) {
        func_196535_a(p_196534_0_, p_196534_1_, (LivingEntity)null);
     }
  
-+   @Deprecated // Forge: Prefer using IForgeBlock#catchFire
++   /**@deprecated Prefer {@link BlockState#catchFire(World, BlockPos, net.minecraft.util.Direction, LivingEntity)}*/@Deprecated
     private static void func_196535_a(World p_196535_0_, BlockPos p_196535_1_, @Nullable LivingEntity p_196535_2_) {
        if (!p_196535_0_.field_72995_K) {
           TNTEntity tntentity = new TNTEntity(p_196535_0_, (double)p_196535_1_.func_177958_n() + 0.5D, (double)p_196535_1_.func_177956_o(), (double)p_196535_1_.func_177952_p() + 0.5D, p_196535_2_);

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -116,7 +116,7 @@
        return this.field_71474_y.field_211842_aO;
     }
  
-+   @Deprecated // Forge: Use selective refreshResources method in FMLClientHandler
++   /**@deprecated Use {@link net.minecraftforge.client.ForgeHooksClient#refreshResources(Minecraft, VanillaResourceType...)}*/@Deprecated
     public CompletableFuture<Void> func_213237_g() {
        if (this.field_213276_aV != null) {
           return this.field_213276_aV;
@@ -448,7 +448,7 @@
        return field_71432_P;
     }
  
-+   @Deprecated // Forge: Use selective scheduleResourceRefresh method in FMLClientHandler
++   /**@deprecated Use {@link net.minecraftforge.client.ForgeHooksClient#refreshResources(Minecraft, net.minecraftforge.resource.VanillaResourceType...)}*/@Deprecated // TODO make an actual replacement for this maybe?
     public CompletableFuture<Void> func_213245_w() {
        return this.func_213169_a(this::func_213237_g).thenCompose((p_229993_0_) -> {
           return p_229993_0_;

--- a/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
@@ -34,12 +34,11 @@
        return iparticlefactory == null ? null : iparticlefactory.func_199234_a(p_199927_1_, this.field_78878_a, p_199927_2_, p_199927_4_, p_199927_6_, p_199927_8_, p_199927_10_, p_199927_12_);
     }
  
-@@ -313,16 +313,29 @@
+@@ -313,16 +313,28 @@
        }
     }
  
-+   /** @deprecated Forge: use {@link #renderParticles(MatrixStack, IRenderTypeBuffer.Impl, LightTexture, ActiveRenderInfo, float, net.minecraft.client.renderer.culling.ClippingHelper)} with ClippingHelper as additional parameter */
-+   @Deprecated
++   /**@deprecated Use {@link #renderParticles(MatrixStack, IRenderTypeBuffer.Impl, LightTexture, ActiveRenderInfo, float, net.minecraft.client.renderer.culling.ClippingHelper)}*/@Deprecated
     public void func_228345_a_(MatrixStack p_228345_1_, IRenderTypeBuffer.Impl p_228345_2_, LightTexture p_228345_3_, ActiveRenderInfo p_228345_4_, float p_228345_5_) {
 +      renderParticles(p_228345_1_, p_228345_2_, p_228345_3_, p_228345_4_, p_228345_5_, null);
 +   }
@@ -65,7 +64,7 @@
           Iterable<Particle> iterable = this.field_78876_b.get(iparticlerendertype);
           if (iterable != null) {
              RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-@@ -331,6 +344,7 @@
+@@ -331,6 +343,7 @@
              iparticlerendertype.func_217600_a(bufferbuilder, this.field_78877_c);
  
              for(Particle particle : iterable) {
@@ -73,7 +72,7 @@
                 try {
                    particle.func_225606_a_(bufferbuilder, p_228345_4_, p_228345_5_);
                 } catch (Throwable throwable) {
-@@ -362,7 +376,7 @@
+@@ -362,7 +375,7 @@
     }
  
     public void func_180533_a(BlockPos p_180533_1_, BlockState p_180533_2_) {
@@ -82,7 +81,7 @@
           VoxelShape voxelshape = p_180533_2_.func_196954_c(this.field_78878_a, p_180533_1_);
           double d0 = 0.25D;
           voxelshape.func_197755_b((p_228348_3_, p_228348_5_, p_228348_7_, p_228348_9_, p_228348_11_, p_228348_13_) -> {
-@@ -434,6 +448,12 @@
+@@ -434,6 +447,12 @@
        return String.valueOf(this.field_78876_b.values().stream().mapToInt(Collection::size).sum());
     }
  

--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
@@ -4,7 +4,7 @@
        this.field_187499_a = p_i46575_1_;
     }
  
-+   @Deprecated // Forge: Model data argument
++   /**@deprecated Use {@link BlockModelRenderer#renderModel(IBlockDisplayReader, IBakedModel, BlockState, BlockPos, MatrixStack, IVertexBuilder, boolean, Random, long, int, net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     public boolean func_228802_a_(IBlockDisplayReader p_228802_1_, IBakedModel p_228802_2_, BlockState p_228802_3_, BlockPos p_228802_4_, MatrixStack p_228802_5_, IVertexBuilder p_228802_6_, boolean p_228802_7_, Random p_228802_8_, long p_228802_9_, int p_228802_11_) {
 -      boolean flag = Minecraft.func_71379_u() && p_228802_3_.func_185906_d() == 0 && p_228802_2_.func_177555_b();
 -      Vector3d vector3d = p_228802_3_.func_191059_e(p_228802_1_, p_228802_4_);
@@ -30,7 +30,7 @@
        }
     }
  
-+   @Deprecated // Forge: Model data argument
++   /**@deprecated Use {@link BlockModelRenderer#renderModelSmooth(IBlockDisplayReader, IBakedModel, BlockState, BlockPos, MatrixStack, IVertexBuilder, boolean, Random, long, int, net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     public boolean func_228805_b_(IBlockDisplayReader p_228805_1_, IBakedModel p_228805_2_, BlockState p_228805_3_, BlockPos p_228805_4_, MatrixStack p_228805_5_, IVertexBuilder p_228805_6_, boolean p_228805_7_, Random p_228805_8_, long p_228805_9_, int p_228805_11_) {
 +       return renderModelSmooth(p_228805_1_, p_228805_2_, p_228805_3_, p_228805_4_, p_228805_5_, p_228805_6_, p_228805_7_, p_228805_8_, p_228805_9_, p_228805_11_, net.minecraftforge.client.model.data.EmptyModelData.INSTANCE);
 +   }
@@ -66,7 +66,7 @@
        return flag;
     }
  
-+   @Deprecated // Forge: Model data argument
++   /**@deprecated Use {@link BlockModelRenderer#renderModelFlat(IBlockDisplayReader, IBakedModel, BlockState, BlockPos, MatrixStack, IVertexBuilder, boolean, Random, long, int, net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     public boolean func_228806_c_(IBlockDisplayReader p_228806_1_, IBakedModel p_228806_2_, BlockState p_228806_3_, BlockPos p_228806_4_, MatrixStack p_228806_5_, IVertexBuilder p_228806_6_, boolean p_228806_7_, Random p_228806_8_, long p_228806_9_, int p_228806_11_) {
 +       return renderModelFlat(p_228806_1_, p_228806_2_, p_228806_3_, p_228806_4_, p_228806_5_, p_228806_6_, p_228806_7_, p_228806_8_, p_228806_9_, p_228806_11_, net.minecraftforge.client.model.data.EmptyModelData.INSTANCE);
 +   }
@@ -103,7 +103,7 @@
  
     }
  
-+   @Deprecated // Forge: Model data argument
++   /**@deprecated Use {@link BlockModelRenderer#renderModel(MatrixStack.Entry, IVertexBuilder, BlockState, IBakedModel, float, float, float, int, int, net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     public void func_228804_a_(MatrixStack.Entry p_228804_1_, IVertexBuilder p_228804_2_, @Nullable BlockState p_228804_3_, IBakedModel p_228804_4_, float p_228804_5_, float p_228804_6_, float p_228804_7_, int p_228804_8_, int p_228804_9_) {
 +      renderModel(p_228804_1_, p_228804_2_, p_228804_3_, p_228804_4_, p_228804_5_, p_228804_6_, p_228804_7_, p_228804_8_, p_228804_9_, net.minecraftforge.client.model.data.EmptyModelData.INSTANCE);
 +   }

--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelShapes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelShapes.java.patch
@@ -4,7 +4,7 @@
        this.field_178128_c = p_i46245_1_;
     }
  
-+   @Deprecated
++   /**@deprecated Use {@link BlockModelShapes#getTexture(BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos)}*/@Deprecated
     public TextureAtlasSprite func_178122_a(BlockState p_178122_1_) {
 -      return this.func_178125_b(p_178122_1_).func_177554_e();
 +      return this.func_178125_b(p_178122_1_).getParticleTexture(net.minecraftforge.client.model.data.EmptyModelData.INSTANCE);

--- a/patches/minecraft/net/minecraft/client/renderer/BlockRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockRendererDispatcher.java.patch
@@ -13,7 +13,7 @@
        return this.field_175028_a;
     }
  
-+   @Deprecated // Forge: Model parameter
++   /**@deprecated Use {@link BlockRendererDispatcher#renderBlockDamage(BlockState, BlockPos, IBlockDisplayReader, MatrixStack, IVertexBuilder, net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     public void func_228792_a_(BlockState p_228792_1_, BlockPos p_228792_2_, IBlockDisplayReader p_228792_3_, MatrixStack p_228792_4_, IVertexBuilder p_228792_5_) {
 -      if (p_228792_1_.func_185901_i() == BlockRenderType.MODEL) {
 -         IBakedModel ibakedmodel = this.field_175028_a.func_178125_b(p_228792_1_);
@@ -29,7 +29,7 @@
        }
     }
  
-+   @Deprecated // Forge: Model parameter
++   /**@deprecated Use {@link BlockRendererDispatcher#renderModel(BlockState, BlockPos, IBlockDisplayReader, MatrixStack, IVertexBuilder, boolean, Random, net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     public boolean func_228793_a_(BlockState p_228793_1_, BlockPos p_228793_2_, IBlockDisplayReader p_228793_3_, MatrixStack p_228793_4_, IVertexBuilder p_228793_5_, boolean p_228793_6_, Random p_228793_7_) {
 +       return renderModel(p_228793_1_, p_228793_2_, p_228793_3_, p_228793_4_, p_228793_5_, p_228793_6_, p_228793_7_, net.minecraftforge.client.model.data.EmptyModelData.INSTANCE);
 +   }
@@ -51,7 +51,7 @@
        return this.field_175028_a.func_178125_b(p_184389_1_);
     }
  
-+   @Deprecated // Forge: Model parameter
++   /**@deprecated Use {@link BlockRendererDispatcher#renderBlock(BlockState, MatrixStack, IRenderTypeBuffer, int, int, net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     public void func_228791_a_(BlockState p_228791_1_, MatrixStack p_228791_2_, IRenderTypeBuffer p_228791_3_, int p_228791_4_, int p_228791_5_) {
 +      renderBlock(p_228791_1_, p_228791_2_, p_228791_3_, p_228791_4_, p_228791_5_, net.minecraftforge.client.model.data.EmptyModelData.INSTANCE);
 +   }

--- a/patches/minecraft/net/minecraft/client/renderer/FluidBlockRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/FluidBlockRenderer.java.patch
@@ -95,7 +95,7 @@
        }
     }
  
-+   @Deprecated
++   /**@deprecated Use {@link FluidBlockRenderer#vertexVanilla(IVertexBuilder, double, double, double, float, float, float, float, float, float, int)}*/@Deprecated
     private void func_228797_a_(IVertexBuilder p_228797_1_, double p_228797_2_, double p_228797_4_, double p_228797_6_, float p_228797_8_, float p_228797_9_, float p_228797_10_, float p_228797_11_, float p_228797_12_, int p_228797_13_) {
 -      p_228797_1_.func_225582_a_(p_228797_2_, p_228797_4_, p_228797_6_).func_227885_a_(p_228797_8_, p_228797_9_, p_228797_10_, 1.0F).func_225583_a_(p_228797_11_, p_228797_12_).func_227886_a_(p_228797_13_).func_225584_a_(0.0F, 1.0F, 0.0F).func_181675_d();
 +       vertexVanilla(p_228797_1_, p_228797_2_, p_228797_4_, p_228797_6_, p_228797_8_, p_228797_9_, p_228797_10_, 1.0F, p_228797_11_, p_228797_12_, p_228797_13_);

--- a/patches/minecraft/net/minecraft/client/renderer/FogRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/FogRenderer.java.patch
@@ -29,12 +29,11 @@
        RenderSystem.clearColor(field_205093_c, field_205094_d, field_205095_e, 0.0F);
     }
  
-@@ -174,10 +185,17 @@
-       RenderSystem.fogDensity(0.0F);
+@@ -175,9 +186,17 @@
        RenderSystem.fogMode(GlStateManager.FogMode.EXP2);
     }
--
-+   @Deprecated // Forge: Pass in partialTicks
+ 
++   /**@deprecated Use {@link FogRenderer#setupFog(ActiveRenderInfo, FogType, float, boolean, float)}*/@Deprecated
     public static void func_228372_a_(ActiveRenderInfo p_228372_0_, FogRenderer.FogType p_228372_1_, float p_228372_2_, boolean p_228372_3_) {
 +      setupFog(p_228372_0_, p_228372_1_, p_228372_2_, p_228372_3_, 0);
 +   }
@@ -48,7 +47,7 @@
        if (fluidstate.func_206884_a(FluidTags.field_206959_a)) {
           float f = 1.0F;
           f = 0.05F;
-@@ -228,6 +246,7 @@
+@@ -228,6 +247,7 @@
           RenderSystem.fogEnd(f3);
           RenderSystem.fogMode(GlStateManager.FogMode.LINEAR);
           RenderSystem.setupNvFogDistance();

--- a/patches/minecraft/net/minecraft/client/renderer/RenderTypeLookup.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderTypeLookup.java.patch
@@ -4,7 +4,7 @@
  
  @OnlyIn(Dist.CLIENT)
  public class RenderTypeLookup {
-+   @Deprecated
++   /**@deprecated Use {@link RenderTypeLookup#canRenderInLayer(BlockState, RenderType)}*/@Deprecated
     private static final Map<Block, RenderType> field_228386_a_ = Util.func_200696_a(Maps.newHashMap(), (p_228395_0_) -> {
        RenderType rendertype = RenderType.func_241715_r_();
        p_228395_0_.put(Blocks.field_150473_bD, rendertype);
@@ -12,7 +12,7 @@
        p_228395_0_.put(Blocks.field_185778_de, rendertype3);
        p_228395_0_.put(Blocks.field_203203_C, rendertype3);
     });
-+   @Deprecated
++   /**@deprecated Use {@link RenderTypeLookup#canRenderInLayer(FluidState, RenderType)}*/@Deprecated
     private static final Map<Fluid, RenderType> field_228387_b_ = Util.func_200696_a(Maps.newHashMap(), (p_228392_0_) -> {
        RenderType rendertype = RenderType.func_228645_f_();
        p_228392_0_.put(Fluids.field_207212_b, rendertype);
@@ -20,7 +20,7 @@
     });
     private static boolean field_228388_c_;
  
-+   @Deprecated // Forge: Use canRenderInLayer
++   /**@deprecated Use {@link RenderTypeLookup#canRenderInLayer(BlockState, RenderType)}*/@Deprecated
     public static RenderType func_228390_a_(BlockState p_228390_0_) {
        Block block = p_228390_0_.func_177230_c();
        if (block instanceof LeavesBlock) {
@@ -28,7 +28,7 @@
        }
     }
  
-+   @Deprecated // Forge: Use canRenderInLayer
++   /**@deprecated Use {@link RenderTypeLookup#canRenderInLayer(BlockState, RenderType)}*/@Deprecated
     public static RenderType func_239221_b_(BlockState p_239221_0_) {
        Block block = p_239221_0_.func_177230_c();
        if (block instanceof LeavesBlock) {
@@ -46,7 +46,7 @@
        }
     }
  
-+   @Deprecated // Forge: Use canRenderInLayer
++   /**@deprecated Use {@link RenderTypeLookup#canRenderInLayer(FluidState, RenderType)}*/@Deprecated
     public static RenderType func_228391_a_(FluidState p_228391_0_) {
        RenderType rendertype = field_228387_b_.get(p_228391_0_.func_206886_c());
        return rendertype != null ? rendertype : RenderType.func_228639_c_();

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -154,7 +154,7 @@
        this.field_175008_n.func_217628_a(p_215319_1_, p_215319_2_, p_215319_3_, p_215319_4_);
     }
  
-+   @Deprecated // Forge: use item aware function below
++   /**@deprecated Use {@link WorldRenderer#playRecord(SoundEvent, BlockPos, MusicDiscItem)}*/@Deprecated
     public void func_184377_a(@Nullable SoundEvent p_184377_1_, BlockPos p_184377_2_) {
 +      this.playRecord(p_184377_1_, p_184377_2_, p_184377_1_ == null? null : MusicDiscItem.func_185074_a(p_184377_1_));
 +   }

--- a/patches/minecraft/net/minecraft/client/renderer/chunk/ChunkRenderDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/chunk/ChunkRenderDispatcher.java.patch
@@ -81,7 +81,7 @@
           @Nullable
           protected ChunkRenderCache field_228938_d_;
  
-+         @Deprecated
++         /**@deprecated Use {@link RebuildTask#RebuildTask(net.minecraft.util.math.ChunkPos, double, ChunkRenderCache)}*/@Deprecated
           public RebuildTask(double p_i226024_2_, @Nullable ChunkRenderCache p_i226024_4_) {
 -            super(p_i226024_2_);
 +            this(null, p_i226024_2_, p_i226024_4_);
@@ -159,7 +159,7 @@
        class SortTransparencyTask extends ChunkRenderDispatcher.ChunkRender.ChunkRenderTask {
           private final ChunkRenderDispatcher.CompiledChunk field_228945_e_;
  
-+         @Deprecated
++         /**@deprecated Use {@link SortTransparencyTask#SortTransparencyTask(net.minecraft.util.math.ChunkPos, double, CompiledChunk)}*/@Deprecated
           public SortTransparencyTask(double p_i226025_2_, ChunkRenderDispatcher.CompiledChunk p_i226025_4_) {
 -            super(p_i226025_2_);
 +            this(null, p_i226025_2_, p_i226025_4_);

--- a/patches/minecraft/net/minecraft/client/renderer/entity/layers/BipedArmorLayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/layers/BipedArmorLayer.java.patch
@@ -42,7 +42,7 @@
        return p_188363_1_ == EquipmentSlotType.LEGS;
     }
  
-+   @Deprecated //Use the more sensitive version getArmorResource below
++   /**@deprecated Use {@link BipedArmorLayer#getArmorResource(net.minecraft.entity.Entity, ItemStack, EquipmentSlotType, String)}*/@Deprecated
     private ResourceLocation func_241737_a_(ArmorItem p_241737_1_, boolean p_241737_2_, @Nullable String p_241737_3_) {
        String s = "textures/models/armor/" + p_241737_1_.func_200880_d().func_200897_d() + "_layer_" + (p_241737_2_ ? 2 : 1) + (p_241737_3_ == null ? "" : "_" + p_241737_3_) + ".png";
        return field_177191_j.computeIfAbsent(s, ResourceLocation::new);

--- a/patches/minecraft/net/minecraft/client/renderer/model/BlockModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/BlockModel.java.patch
@@ -53,7 +53,7 @@
        return set1;
     }
  
-+   @Deprecated // Forge: Use Boolean variant
++   /**@deprecated Use {@link BlockModel#bakeModel(ModelBakery, BlockModel, Function, IModelTransform, ResourceLocation, boolean)}*/@Deprecated
     public IBakedModel func_225613_a_(ModelBakery p_225613_1_, Function<RenderMaterial, TextureAtlasSprite> p_225613_2_, IModelTransform p_225613_3_, ResourceLocation p_225613_4_) {
        return this.func_228813_a_(p_225613_1_, this, p_225613_2_, p_225613_3_, p_225613_4_, true);
     }
@@ -62,7 +62,7 @@
 +      return net.minecraftforge.client.model.ModelLoaderRegistry.bakeHelper(this, p_228813_1_, p_228813_2_, p_228813_3_, p_228813_4_, p_228813_5_, p_228813_6_);
 +   }
 +
-+   @Deprecated // Forge: Exposed for our callbacks only. Use the above function.
++   /**@deprecated For Forge callbacks only. Use {@link BlockModel#bakeModel(ModelBakery, BlockModel, Function, IModelTransform, ResourceLocation, boolean)}*/@Deprecated
 +   public IBakedModel bakeVanilla(ModelBakery p_228813_1_, BlockModel p_228813_2_, Function<RenderMaterial, TextureAtlasSprite> p_228813_3_, IModelTransform p_228813_4_, ResourceLocation p_228813_5_, boolean p_228813_6_) {
        TextureAtlasSprite textureatlassprite = p_228813_3_.apply(this.func_228816_c_("particle"));
        if (this.func_178310_f() == ModelBakery.field_177616_r) {

--- a/patches/minecraft/net/minecraft/client/renderer/model/IBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/IBakedModel.java.patch
@@ -1,27 +1,24 @@
 --- a/net/minecraft/client/renderer/model/IBakedModel.java
 +++ b/net/minecraft/client/renderer/model/IBakedModel.java
-@@ -10,7 +10,9 @@
+@@ -10,7 +10,8 @@
  import net.minecraftforge.api.distmarker.OnlyIn;
  
  @OnlyIn(Dist.CLIENT)
 -public interface IBakedModel {
 +public interface IBakedModel extends net.minecraftforge.client.extensions.IForgeBakedModel {
-+   /**@deprecated Forge: Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#getQuads(IBlockState, EnumFacing, Random, net.minecraftforge.client.model.data.IModelData)}*/
-+   @Deprecated
++   /**@deprecated Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#getQuads(BlockState, Direction, Random, net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     List<BakedQuad> func_200117_a(@Nullable BlockState p_200117_1_, @Nullable Direction p_200117_2_, Random p_200117_3_);
  
     boolean func_177555_b();
-@@ -21,9 +23,13 @@
+@@ -21,9 +22,11 @@
  
     boolean func_188618_c();
  
-+   /**@deprecated Forge: Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#getParticleTexture(net.minecraftforge.client.model.data.IModelData)}*/
-+   @Deprecated
++   /**@deprecated Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#getParticleTexture(net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     TextureAtlasSprite func_177554_e();
  
 -   ItemCameraTransforms func_177552_f();
-+   /**@deprecated Forge: Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#handlePerspective(net.minecraft.client.renderer.model.ItemCameraTransforms.TransformType, com.mojang.blaze3d.matrix.MatrixStack)} instead */
-+   @Deprecated
++   /**@deprecated Use {@link net.minecraftforge.client.extensions.IForgeBakedModel#handlePerspective(net.minecraft.client.renderer.model.ItemCameraTransforms.TransformType, com.mojang.blaze3d.matrix.MatrixStack)}*/@Deprecated
 +   default ItemCameraTransforms func_177552_f() { return ItemCameraTransforms.field_178357_a; }
  
     ItemOverrideList func_188617_f();

--- a/patches/minecraft/net/minecraft/client/renderer/model/ItemCameraTransforms.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/ItemCameraTransforms.java.patch
@@ -4,7 +4,7 @@
        this(ItemTransformVec3f.field_178366_a, ItemTransformVec3f.field_178366_a, ItemTransformVec3f.field_178366_a, ItemTransformVec3f.field_178366_a, ItemTransformVec3f.field_178366_a, ItemTransformVec3f.field_178366_a, ItemTransformVec3f.field_178366_a, ItemTransformVec3f.field_178366_a);
     }
  
-+   @Deprecated
++   /**@deprecated Modders shouldn't use this. This is handled by Forge.*/@Deprecated
     public ItemCameraTransforms(ItemCameraTransforms p_i46443_1_) {
        this.field_188036_k = p_i46443_1_.field_188036_k;
        this.field_188037_l = p_i46443_1_.field_188037_l;
@@ -12,7 +12,7 @@
        this.field_181700_p = p_i46443_1_.field_181700_p;
     }
  
-+   @Deprecated
++   /**@deprecated Modders shouldn't use this. This is handled by Forge.*/@Deprecated
     public ItemCameraTransforms(ItemTransformVec3f p_i46569_1_, ItemTransformVec3f p_i46569_2_, ItemTransformVec3f p_i46569_3_, ItemTransformVec3f p_i46569_4_, ItemTransformVec3f p_i46569_5_, ItemTransformVec3f p_i46569_6_, ItemTransformVec3f p_i46569_7_, ItemTransformVec3f p_i46569_8_) {
        this.field_188036_k = p_i46569_1_;
        this.field_188037_l = p_i46569_2_;
@@ -20,7 +20,7 @@
        this.field_181700_p = p_i46569_8_;
     }
  
-+   @Deprecated
++   /**@deprecated Modders shouldn't use this. This is handled by Forge.*/@Deprecated
     public ItemTransformVec3f func_181688_b(ItemCameraTransforms.TransformType p_181688_1_) {
        switch(p_181688_1_) {
        case THIRD_PERSON_LEFT_HAND:

--- a/patches/minecraft/net/minecraft/client/renderer/model/ItemOverrideList.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/ItemOverrideList.java.patch
@@ -4,7 +4,7 @@
        this.field_209582_c = Collections.emptyList();
     }
  
-+   @Deprecated // Forge: Use IUnbakedModel, add texture getter
++   /**@deprecated Use {@link ItemOverrideList#ItemOverrideList(ModelBakery, IUnbakedModel, Function, Function, List)}*/@Deprecated
     public ItemOverrideList(ModelBakery p_i50984_1_, BlockModel p_i50984_2_, Function<ResourceLocation, IUnbakedModel> p_i50984_3_, List<ItemOverride> p_i50984_4_) {
 +      this(p_i50984_1_, (IUnbakedModel)p_i50984_2_, p_i50984_3_, p_i50984_1_.getSpriteMap()::func_229151_a_, p_i50984_4_);
 +   }

--- a/patches/minecraft/net/minecraft/client/renderer/model/ItemTransformVec3f.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/ItemTransformVec3f.java.patch
@@ -1,12 +1,10 @@
 --- a/net/minecraft/client/renderer/model/ItemTransformVec3f.java
 +++ b/net/minecraft/client/renderer/model/ItemTransformVec3f.java
-@@ -14,7 +14,9 @@
+@@ -14,6 +14,7 @@
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
  
-+/** @deprecated Use {@link net.minecraft.util.math.vector.TransformationMatrix} through {@link net.minecraftforge.client.extensions.IForgeBakedModel#handlePerspective */
++/**@deprecated Use {@link net.minecraft.util.math.vector.TransformationMatrix} through {@link net.minecraftforge.client.extensions.IForgeBakedModel#handlePerspective}*/@Deprecated
  @OnlyIn(Dist.CLIENT)
-+@Deprecated
  public class ItemTransformVec3f {
     public static final ItemTransformVec3f field_178366_a = new ItemTransformVec3f(new Vector3f(), new Vector3f(), new Vector3f(1.0F, 1.0F, 1.0F));
-    public final Vector3f field_178364_b;

--- a/patches/minecraft/net/minecraft/client/renderer/model/ModelBakery.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/ModelBakery.java.patch
@@ -57,11 +57,12 @@
     private void func_217843_a(ModelResourceLocation p_217843_1_) {
        IUnbakedModel iunbakedmodel = this.func_209597_a(p_217843_1_);
        this.field_217849_F.put(p_217843_1_, iunbakedmodel);
-@@ -456,7 +477,13 @@
+@@ -455,8 +476,14 @@
+       });
     }
  
++   /**@deprecated Use {@link ModelBakery#getBakedModel(ResourceLocation, IModelTransform, java.util.function.Function)}*/@Deprecated
     @Nullable
-+   @Deprecated
     public IBakedModel func_217845_a(ResourceLocation p_217845_1_, IModelTransform p_217845_2_) {
 +      return getBakedModel(p_217845_1_, p_217845_2_, this.field_229322_z_::func_229151_a_);
 +   }

--- a/patches/minecraft/net/minecraft/client/renderer/model/MultipartBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/MultipartBakedModel.java.patch
@@ -56,7 +56,7 @@
        return false;
     }
  
-+   @Deprecated
++   /**@deprecated Use {@link MultipartBakedModel#getParticleTexture(net.minecraftforge.client.model.data.IModelData)}*/@Deprecated
     public TextureAtlasSprite func_177554_e() {
        return this.field_188623_c;
     }
@@ -65,7 +65,7 @@
 +      return this.defaultModel.getParticleTexture(modelData);
 +   }
 +
-+   @Deprecated
++   /**@deprecated If you're a modder, you should probably be using {@link MultipartBakedModel#handlePerspective(net.minecraft.client.renderer.model.ItemCameraTransforms.TransformType, com.mojang.blaze3d.matrix.MatrixStack)}*/@Deprecated
     public ItemCameraTransforms func_177552_f() {
        return this.field_188624_d;
     }

--- a/patches/minecraft/net/minecraft/data/BlockTagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/BlockTagsProvider.java.patch
@@ -4,7 +4,7 @@
  import net.minecraft.util.registry.Registry;
  
  public class BlockTagsProvider extends TagsProvider<Block> {
-+   @Deprecated
++   /**@deprecated Use {@link BlockTagsProvider#BlockTagsProvider(DataGenerator, String, net.minecraftforge.common.data.ExistingFileHelper)}*/@Deprecated
     public BlockTagsProvider(DataGenerator p_i48256_1_) {
        super(p_i48256_1_, Registry.field_212618_g);
     }

--- a/patches/minecraft/net/minecraft/data/EntityTypeTagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/EntityTypeTagsProvider.java.patch
@@ -4,7 +4,7 @@
  import net.minecraft.util.registry.Registry;
  
  public class EntityTypeTagsProvider extends TagsProvider<EntityType<?>> {
-+   @Deprecated
++   /**@deprecated Use {@link EntityTypeTagsProvider#EntityTypeTagsProvider(DataGenerator, String, net.minecraftforge.common.data.ExistingFileHelper)}*/@Deprecated
     public EntityTypeTagsProvider(DataGenerator p_i50784_1_) {
        super(p_i50784_1_, Registry.field_212629_r);
     }

--- a/patches/minecraft/net/minecraft/data/FluidTagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/FluidTagsProvider.java.patch
@@ -4,7 +4,7 @@
  import net.minecraft.util.registry.Registry;
  
  public class FluidTagsProvider extends TagsProvider<Fluid> {
-+   @Deprecated
++   /**@deprecated Use {@link FluidTagsProvider#FluidTagsProvider(DataGenerator, String, net.minecraftforge.common.data.ExistingFileHelper)}*/@Deprecated
     public FluidTagsProvider(DataGenerator p_i49156_1_) {
        super(p_i49156_1_, Registry.field_212619_h);
     }

--- a/patches/minecraft/net/minecraft/data/ItemTagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/ItemTagsProvider.java.patch
@@ -4,7 +4,7 @@
  public class ItemTagsProvider extends TagsProvider<Item> {
     private final Function<ITag.INamedTag<Block>, ITag.Builder> field_240520_d_;
  
-+   @Deprecated
++   /**@deprecated Use {@link ItemTagsProvider#ItemTagsProvider(DataGenerator, BlockTagsProvider, String, net.minecraftforge.common.data.ExistingFileHelper)}*/@Deprecated
     public ItemTagsProvider(DataGenerator p_i232552_1_, BlockTagsProvider p_i232552_2_) {
        super(p_i232552_1_, Registry.field_212630_s);
        this.field_240520_d_ = p_i232552_2_::func_240525_b_;

--- a/patches/minecraft/net/minecraft/data/TagsProvider.java.patch
+++ b/patches/minecraft/net/minecraft/data/TagsProvider.java.patch
@@ -8,7 +8,7 @@
 +   protected final net.minecraftforge.common.data.ExistingFileHelper existingFileHelper;
 +   private final net.minecraftforge.common.data.ExistingFileHelper.IResourceType resourceType;
  
-+   @Deprecated//Forge, Use ModID version.
++   /**@deprecated Use {@link TagsProvider#TagsProvider(DataGenerator, Registry, String, net.minecraftforge.common.data.ExistingFileHelper)}*/@Deprecated
     protected TagsProvider(DataGenerator p_i49827_1_, Registry<T> p_i49827_2_) {
 +      this(p_i49827_1_, p_i49827_2_, "vanilla", null);
 +   }

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -11,7 +11,7 @@
     private static final List<ItemStack> field_190535_b = Collections.emptyList();
     private static final AxisAlignedBB field_174836_a = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 0.0D, 0.0D, 0.0D);
     private static double field_70155_l = 1.0D;
-+   @Deprecated // Forge: Use the getter to allow overriding in mods
++   /**@deprecated Use {@link Entity#getType()}*/@Deprecated
     private final EntityType<?> field_200606_g;
     private int field_145783_c = field_213331_b.incrementAndGet();
     public boolean field_70156_m;
@@ -19,7 +19,7 @@
     public boolean field_70124_G;
     public boolean field_70133_I;
     protected Vector3d field_213328_B = Vector3d.field_186680_a;
-+   @Deprecated // Forge: Use isAlive, remove(boolean) and revive() instead of directly accessing this field. To allow the entity to react to and better control this information.
++   /**@deprecated Use {@link Entity#isAlive()}, {@link Entity#remove(boolean)}, and {@link Entity#revive()} to allow the entity to react to and better control this information*/@Deprecated
     public boolean field_70128_L;
     public float field_70141_P;
     public float field_70140_Q;
@@ -205,7 +205,7 @@
        return !this.func_184188_bt().isEmpty();
     }
  
-+   @Deprecated // Forge: Use rider sensitive version
++   /**@deprecated Use {@link Entity#canBeRiddenInWater(Entity)}*/@Deprecated
     public boolean func_205710_ba() {
        return true;
     }

--- a/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityClassification.java.patch
@@ -26,8 +26,8 @@
 +      throw new IllegalStateException("Enum not extended");
 +   }
 +
++   /**@deprecated For Forge use only! Modders stay away!*/@Deprecated
 +   @Override
-+   @Deprecated
 +   public void init() {
 +      field_220364_f.put(this.func_220363_a(), this);
 +   }

--- a/patches/minecraft/net/minecraft/entity/IShearable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/IShearable.java.patch
@@ -4,11 +4,11 @@
  
  import net.minecraft.util.SoundCategory;
  
-+@Deprecated // Forge: Use IForgeShearable
++/**@deprecated Use {@link net.minecraftforge.common.IForgeShearable}*/@Deprecated
  public interface IShearable {
-+   @Deprecated // Forge: Use IForgeShearable
++   /**@deprecated Use {@link net.minecraftforge.common.IForgeShearable#onSheared(net.minecraft.entity.player.PlayerEntity, net.minecraft.item.ItemStack, net.minecraft.world.World, net.minecraft.util.math.BlockPos, int)}*/@Deprecated
     void func_230263_a_(SoundCategory p_230263_1_);
  
-+   @Deprecated // Forge: Use IForgeShearable
++   /**@deprecated Use {@link net.minecraftforge.common.IForgeShearable#isShearable(net.minecraft.item.ItemStack, net.minecraft.world.World, net.minecraft.util.math.BlockPos)}*/@Deprecated
     boolean func_230262_K__();
  }

--- a/patches/minecraft/net/minecraft/entity/boss/WitherEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/WitherEntity.java.patch
@@ -31,7 +31,7 @@
        }
     }
  
-+   @Deprecated // Forge: DO NOT USE! Use BlockState.canEntityDestroy
++   /**@deprecated Use {@link BlockState#canEntityDestroy(net.minecraft.world.IBlockReader, BlockPos, Entity)}*/@Deprecated
     public static boolean func_181033_a(BlockState p_181033_0_) {
        return !p_181033_0_.func_196958_f() && !BlockTags.field_219755_X.func_230235_a_(p_181033_0_.func_177230_c());
     }

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -92,7 +92,7 @@
        }
     }
  
-+   @Deprecated //Use location sensitive version below
++   /**@deprecated Use {@link PlayerEntity#getDigSpeed(BlockState, BlockPos)}*/@Deprecated
     public float func_184813_a(BlockState p_184813_1_) {
 +      return getDigSpeed(p_184813_1_, null);
 +   }

--- a/patches/minecraft/net/minecraft/fluid/FluidState.java.patch
+++ b/patches/minecraft/net/minecraft/fluid/FluidState.java.patch
@@ -13,7 +13,7 @@
        return this.func_206886_c().func_207185_a(p_206884_1_);
     }
  
-+   @Deprecated // Forge: Use more sensitive version
++   /**@deprecated Use {@link FluidState#getExplosionResistance(IBlockReader, BlockPos, net.minecraft.world.Explosion)}*/@Deprecated
     public float func_210200_l() {
        return this.func_206886_c().func_210195_d();
     }

--- a/patches/minecraft/net/minecraft/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BlockItem.java.patch
@@ -15,7 +15,7 @@
        }
     }
  
-+   @Deprecated //Forge: Use more sensitive version {@link BlockItem#getPlaceSound(BlockState, IBlockReader, BlockPos, Entity) }
++   /**@deprecated Use {@link BlockItem#getPlaceSound(BlockState, World, BlockPos, PlayerEntity)}*/@Deprecated
     protected SoundEvent func_219983_a(BlockState p_219983_1_) {
        return p_219983_1_.func_215695_r().func_185841_e();
     }

--- a/patches/minecraft/net/minecraft/item/BoneMealItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BoneMealItem.java.patch
@@ -13,7 +13,7 @@
        }
     }
  
-+   @Deprecated //Forge: Use Player/Hand version
++   /**@deprecated Use {@link BoneMealItem#applyBonemeal(ItemStack, World, BlockPos, net.minecraft.entity.player.PlayerEntity)}*/@Deprecated
     public static boolean func_195966_a(ItemStack p_195966_0_, World p_195966_1_, BlockPos p_195966_2_) {
 +      if (p_195966_1_ instanceof net.minecraft.world.server.ServerWorld)
 +         return applyBonemeal(p_195966_0_, p_195966_1_, p_195966_2_, net.minecraftforge.common.util.FakePlayerFactory.getMinecraft((net.minecraft.world.server.ServerWorld)p_195966_1_));

--- a/patches/minecraft/net/minecraft/item/BucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BucketItem.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/item/BucketItem.java
 +++ b/net/minecraft/item/BucketItem.java
-@@ -32,14 +32,28 @@
+@@ -32,14 +32,27 @@
  public class BucketItem extends Item {
     private final Fluid field_77876_a;
  
-+   // Forge: Use the other constructor that takes a Supplier
-+   @Deprecated
++   /**@deprecated Use {@link BucketItem#BucketItem(java.util.function.Supplier, Item.Properties)}*/@Deprecated
     public BucketItem(Fluid p_i49025_1_, Item.Properties p_i49025_2_) {
        super(p_i49025_2_);
        this.field_77876_a = p_i49025_1_;
@@ -29,7 +28,7 @@
        if (raytraceresult.func_216346_c() == RayTraceResult.Type.MISS) {
           return ActionResult.func_226250_c_(itemstack);
        } else if (raytraceresult.func_216346_c() != RayTraceResult.Type.BLOCK) {
-@@ -56,7 +70,10 @@
+@@ -56,7 +69,10 @@
                    Fluid fluid = ((IBucketPickupHandler)blockstate1.func_177230_c()).func_204508_a(p_77659_1_, blockpos, blockstate1);
                    if (fluid != Fluids.field_204541_a) {
                       p_77659_2_.func_71029_a(Stats.field_75929_E.func_199076_b(this));
@@ -41,7 +40,7 @@
                       ItemStack itemstack1 = DrinkHelper.func_242398_a(itemstack, p_77659_2_, new ItemStack(fluid.func_204524_b()));
                       if (!p_77659_1_.field_72995_K) {
                          CriteriaTriggers.field_204813_j.func_204817_a((ServerPlayerEntity)p_77659_2_, new ItemStack(fluid.func_204524_b()));
-@@ -69,7 +86,7 @@
+@@ -69,7 +85,7 @@
                 return ActionResult.func_226251_d_(itemstack);
              } else {
                 BlockState blockstate = p_77659_1_.func_180495_p(blockpos);
@@ -50,7 +49,7 @@
                 if (this.func_180616_a(p_77659_2_, p_77659_1_, blockpos2, blockraytraceresult)) {
                    this.func_203792_a(p_77659_1_, itemstack, blockpos2);
                    if (p_77659_2_ instanceof ServerPlayerEntity) {
-@@ -117,7 +134,7 @@
+@@ -117,7 +133,7 @@
              }
  
              return true;
@@ -59,7 +58,7 @@
              ((ILiquidContainer)block).func_204509_a(p_180616_2_, p_180616_3_, blockstate, ((FlowingFluid)this.field_77876_a).func_207204_a(false));
              this.func_203791_b(p_180616_1_, p_180616_2_, p_180616_3_);
              return true;
-@@ -137,7 +154,24 @@
+@@ -137,7 +153,24 @@
     }
  
     protected void func_203791_b(@Nullable PlayerEntity p_203791_1_, IWorld p_203791_2_, BlockPos p_203791_3_) {

--- a/patches/minecraft/net/minecraft/item/FishBucketItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/FishBucketItem.java.patch
@@ -4,7 +4,7 @@
  public class FishBucketItem extends BucketItem {
     private final EntityType<?> field_203794_a;
  
-+   @Deprecated
++   /**@deprecated Use {@link FishBucketItem#FishBucketItem(java.util.function.Supplier, java.util.function.Supplier, Item.Properties)}*/@Deprecated
     public FishBucketItem(EntityType<?> p_i49022_1_, Fluid p_i49022_2_, Item.Properties p_i49022_3_) {
        super(p_i49022_2_, p_i49022_3_);
        this.field_203794_a = p_i49022_1_;

--- a/patches/minecraft/net/minecraft/item/Food.java.patch
+++ b/patches/minecraft/net/minecraft/item/Food.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/item/Food.java
 +++ b/net/minecraft/item/Food.java
-@@ -11,15 +11,26 @@
+@@ -11,15 +11,25 @@
     private final boolean field_221472_c;
     private final boolean field_221473_d;
     private final boolean field_221474_e;
@@ -16,8 +16,7 @@
 +      this.field_221475_f = builder.field_221463_f;
 +   }
 +
-+   // Forge: Use builder method instead
-+   @Deprecated
++   /**@deprecated Use {@link Food.Builder}*/@Deprecated
     private Food(int p_i50106_1_, float p_i50106_2_, boolean p_i50106_3_, boolean p_i50106_4_, boolean p_i50106_5_, List<Pair<EffectInstance, Float>> p_i50106_6_) {
        this.field_221470_a = p_i50106_1_;
        this.field_221471_b = p_i50106_2_;
@@ -29,7 +28,7 @@
     }
  
     public int func_221466_a() {
-@@ -43,7 +54,7 @@
+@@ -43,7 +53,7 @@
     }
  
     public List<Pair<EffectInstance, Float>> func_221464_f() {
@@ -38,7 +37,7 @@
     }
  
     public static class Builder {
-@@ -52,7 +63,7 @@
+@@ -52,7 +62,7 @@
        private boolean field_221460_c;
        private boolean field_221461_d;
        private boolean field_221462_e;
@@ -47,7 +46,7 @@
  
        public Food.Builder func_221456_a(int p_221456_1_) {
           this.field_221458_a = p_221456_1_;
-@@ -79,13 +90,20 @@
+@@ -79,13 +89,19 @@
           return this;
        }
  
@@ -56,8 +55,7 @@
 +          return this;
 +       }
 +
-+      // Forge: Use supplier method instead
-+      @Deprecated
++      /**@deprecated Use {@link Builder#effect(java.util.function.Supplier, float)}*/@Deprecated
        public Food.Builder func_221452_a(EffectInstance p_221452_1_, float p_221452_2_) {
 -         this.field_221463_f.add(Pair.of(p_221452_1_, p_221452_2_));
 +         this.field_221463_f.add(Pair.of(() -> p_221452_1_, p_221452_2_));

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -26,12 +26,12 @@
        return this.func_219971_r() ? p_77654_3_.func_213357_a(p_77654_2_, p_77654_1_) : p_77654_1_;
     }
  
-+   @Deprecated // Use ItemStack sensitive version.
++   /**@deprecated Use {@link ItemStack#getMaxStackSize()}*/@Deprecated
     public final int func_77639_j() {
        return this.field_77777_bU;
     }
  
-+   @Deprecated // Use ItemStack sensitive version.
++   /**@deprecated Use {@link ItemStack#getMaxDamage()}*/@Deprecated
     public final int func_77612_l() {
        return this.field_77699_b;
     }
@@ -39,12 +39,12 @@
     }
  
     @Nullable
-+   @Deprecated // Use ItemStack sensitive version.
++   /**@deprecated Use {@link ItemStack#getContainerItem()}*/@Deprecated
     public final Item func_77668_q() {
        return this.field_77700_c;
     }
  
-+   @Deprecated // Use ItemStack sensitive version.
++   /**@deprecated Use {@link ItemStack#hasContainerItem()}*/@Deprecated
     public boolean func_77634_r() {
        return this.field_77700_c != null;
     }
@@ -80,7 +80,7 @@
        return false;
     }
  
-+   @Deprecated // Use ItemStack sensitive version.
++   /**@deprecated Use {@link ItemStack#getAttributeModifiers(EquipmentSlotType)}*/@Deprecated
     public Multimap<Attribute, AttributeModifier> func_111205_h(EquipmentSlotType p_111205_1_) {
        return ImmutableMultimap.of();
     }

--- a/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/MusicDiscItem.java.patch
@@ -4,14 +4,14 @@
  import net.minecraftforge.api.distmarker.OnlyIn;
  
  public class MusicDiscItem extends Item {
-+   @Deprecated // Forge: refer to WorldRender#playRecord. Modders: there's no need to reflectively modify this map!
++   /**@deprecated Use {@link net.minecraft.client.renderer.WorldRenderer#playRecord(SoundEvent, BlockPos, MusicDiscItem)}. Modders don't need to modify this map.*/@Deprecated
     private static final Map<SoundEvent, MusicDiscItem> field_150928_b = Maps.newHashMap();
     private final int field_195977_c;
-+   @Deprecated // Forge: refer to soundSupplier
++   /**@deprecated Use {@link MusicDiscItem#soundSupplier}*/@Deprecated
     private final SoundEvent field_185076_b;
 +   private final java.util.function.Supplier<SoundEvent> soundSupplier;
  
-+   @Deprecated // Forge: Use the constructor that takes a supplier instead
++   /**@deprecated Use {@link MusicDiscItem#MusicDiscItem(int, java.util.function.Supplier, Item.Properties)}*/@Deprecated
     public MusicDiscItem(int p_i48475_1_, SoundEvent p_i48475_2_, Item.Properties p_i48475_3_) {
        super(p_i48475_3_);
        this.field_195977_c = p_i48475_1_;

--- a/patches/minecraft/net/minecraft/loot/LootTable.java.patch
+++ b/patches/minecraft/net/minecraft/loot/LootTable.java.patch
@@ -20,7 +20,7 @@
  
     }
  
-+   @Deprecated // Forge: Use other method or manually call ForgeHooks.modifyLoot
++   /**@deprecated Use {@link LootTable#generate(LootContext)} or {@link net.minecraftforge.common.ForgeHooks#modifyLoot(List, LootContext)}*/@Deprecated
     public void func_216120_b(LootContext p_216120_1_, Consumer<ItemStack> p_216120_2_) {
        this.func_216114_a(p_216120_1_, func_216124_a(p_216120_2_));
     }

--- a/patches/minecraft/net/minecraft/resources/IResourceManagerReloadListener.java.patch
+++ b/patches/minecraft/net/minecraft/resources/IResourceManagerReloadListener.java.patch
@@ -1,18 +1,14 @@
 --- a/net/minecraft/resources/IResourceManagerReloadListener.java
 +++ b/net/minecraft/resources/IResourceManagerReloadListener.java
-@@ -5,6 +5,11 @@
+@@ -5,6 +5,7 @@
  import net.minecraft.profiler.IProfiler;
  import net.minecraft.util.Unit;
  
-+/**
-+ * @deprecated Forge: {@link net.minecraftforge.resource.ISelectiveResourceReloadListener}, which selectively allows
-+ * individual resource types being reloaded should rather be used where possible.
-+ */
-+@Deprecated
++/**@deprecated Use {@link net.minecraftforge.resource.ISelectiveResourceReloadListener}*/@Deprecated
  public interface IResourceManagerReloadListener extends IFutureReloadListener {
     default CompletableFuture<Void> func_215226_a(IFutureReloadListener.IStage p_215226_1_, IResourceManager p_215226_2_, IProfiler p_215226_3_, IProfiler p_215226_4_, Executor p_215226_5_, Executor p_215226_6_) {
        return p_215226_1_.func_216872_a(Unit.INSTANCE).thenRunAsync(() -> {
-@@ -17,4 +22,9 @@
+@@ -17,4 +18,9 @@
     }
  
     void func_195410_a(IResourceManager p_195410_1_);

--- a/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
@@ -12,7 +12,7 @@
        return null;
     }
  
-+   @Deprecated
++   /**@deprecated Use {@link ResourcePackInfo#ResourcePackInfo(String, boolean, Supplier, ITextComponent, ITextComponent, PackCompatibility, ResourcePackInfo.Priority, boolean, IPackNameDecorator, boolean)}*/@Deprecated
     public ResourcePackInfo(String p_i231422_1_, boolean p_i231422_2_, Supplier<IResourcePack> p_i231422_3_, ITextComponent p_i231422_4_, ITextComponent p_i231422_5_, PackCompatibility p_i231422_6_, ResourcePackInfo.Priority p_i231422_7_, boolean p_i231422_8_, IPackNameDecorator p_i231422_9_) {
 +       this(p_i231422_1_, p_i231422_2_, p_i231422_3_, p_i231422_4_, p_i231422_5_, p_i231422_6_, p_i231422_7_, p_i231422_8_, p_i231422_9_, false);
 +   }
@@ -28,7 +28,7 @@
 +      this.hidden = hidden;
     }
  
-+   @Deprecated
++   /**@deprecated Use {@link ResourcePackInfo#ResourcePackInfo(String, boolean, Supplier, IResourcePack, PackMetadataSection, Priority, IPackNameDecorator, boolean)}*/@Deprecated
     public ResourcePackInfo(String p_i231421_1_, boolean p_i231421_2_, Supplier<IResourcePack> p_i231421_3_, IResourcePack p_i231421_4_, PackMetadataSection p_i231421_5_, ResourcePackInfo.Priority p_i231421_6_, IPackNameDecorator p_i231421_7_) {
 -      this(p_i231421_1_, p_i231421_2_, p_i231421_3_, new StringTextComponent(p_i231421_4_.func_195762_a()), p_i231421_5_.func_198963_a(), PackCompatibility.func_198969_a(p_i231421_5_.func_198962_b()), p_i231421_6_, false, p_i231421_7_);
 +       this(p_i231421_1_, p_i231421_2_, p_i231421_3_, p_i231421_4_, p_i231421_5_, p_i231421_6_, p_i231421_7_, false);

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -181,14 +181,14 @@
 +      return perWorldTickTimes.get(dim);
 +   }
 +
-+   @Deprecated // Forge: INTERNAL USE ONLY! You can screw up a lot of things if you mess with this map.
++   /**@deprecated For Forge use only, modders stay away! Many things can go wrong if you mess with this map.*/@Deprecated
 +   public synchronized Map<RegistryKey<World>, ServerWorld> forgeGetWorldMap() {
 +      return this.field_71305_c;
 +   }
 +   private int worldArrayMarker = 0;
 +   private int worldArrayLast = -1;
 +   private ServerWorld[] worldArray;
-+   @Deprecated // Forge: INTERNAL USE ONLY! Use to protect against concurrent modifications in the world tick loop.
++   /**@deprecated For Forge use only, modders stay away! Used to prevent {@link java.util.ConcurrentModificationException}s in the world tick loop.*/@Deprecated
 +   public synchronized void markWorldsDirty() {
 +      worldArrayMarker++;
 +   }

--- a/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/AbstractFurnaceTileEntity.java.patch
@@ -4,7 +4,7 @@
        this.field_214014_c = p_i49964_2_;
     }
  
-+   @Deprecated // Forge: get burn times by calling ForgeHooks#getBurnTime(ItemStack)
++   /**@deprecated Use {@link net.minecraftforge.common.ForgeHooks#getBurnTime(ItemStack)}*/@Deprecated
     public static Map<Item, Integer> func_214001_f() {
        Map<Item, Integer> map = Maps.newLinkedHashMap();
        func_213996_a(map, Items.field_151129_at, 20000);

--- a/patches/minecraft/net/minecraft/util/registry/Registry.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/Registry.java.patch
@@ -11,171 +11,202 @@
  public abstract class Registry<T> implements Codec<T>, Keyable, IObjectIntIterable<T> {
     protected static final Logger field_212616_e = LogManager.getLogger();
     private static final Map<ResourceLocation, Supplier<?>> field_218376_a = Maps.newLinkedHashMap();
-@@ -133,43 +137,43 @@
+@@ -133,43 +137,55 @@
     public static final RegistryKey<Registry<DimensionType>> field_239698_ad_ = func_239741_a_("dimension_type");
     public static final RegistryKey<Registry<World>> field_239699_ae_ = func_239741_a_("dimension");
     public static final RegistryKey<Registry<Dimension>> field_239700_af_ = func_239741_a_("dimension");
 -   public static final Registry<SoundEvent> field_212633_v = func_239746_a_(field_239708_i_, () -> {
-+   @Deprecated public static final Registry<SoundEvent> field_212633_v = forge(field_239708_i_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#SOUND_EVENTS}*/@Deprecated
++   public static final Registry<SoundEvent> field_212633_v = forge(field_239708_i_, () -> {
        return SoundEvents.field_187638_cR;
     });
 -   public static final DefaultedRegistry<Fluid> field_212619_h = func_239745_a_(field_239709_j_, "empty", () -> {
-+   @Deprecated public static final DefaultedRegistry<Fluid> field_212619_h = forge(field_239709_j_, "empty", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#FLUIDS}*/@Deprecated
++   public static final DefaultedRegistry<Fluid> field_212619_h = forge(field_239709_j_, "empty", () -> {
        return Fluids.field_204541_a;
     });
 -   public static final Registry<Effect> field_212631_t = func_239746_a_(field_239710_k_, () -> {
-+   @Deprecated public static final Registry<Effect> field_212631_t = forge(field_239710_k_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#POTIONS}*/@Deprecated
++   public static final Registry<Effect> field_212631_t = forge(field_239710_k_, () -> {
        return Effects.field_188425_z;
     });
 -   public static final DefaultedRegistry<Block> field_212618_g = func_239745_a_(field_239711_l_, "air", () -> {
-+   @Deprecated public static final DefaultedRegistry<Block> field_212618_g = forge(field_239711_l_, "air", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#BLOCKS}*/@Deprecated
++   public static final DefaultedRegistry<Block> field_212618_g = forge(field_239711_l_, "air", () -> {
        return Blocks.field_150350_a;
     });
 -   public static final Registry<Enchantment> field_212628_q = func_239746_a_(field_239712_m_, () -> {
-+   @Deprecated public static final Registry<Enchantment> field_212628_q = forge(field_239712_m_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#ENCHANTMENTS}*/@Deprecated
++   public static final Registry<Enchantment> field_212628_q = forge(field_239712_m_, () -> {
        return Enchantments.field_185308_t;
     });
 -   public static final DefaultedRegistry<EntityType<?>> field_212629_r = func_239745_a_(field_239713_n_, "pig", () -> {
-+   @Deprecated public static final DefaultedRegistry<EntityType<?>> field_212629_r = forge(field_239713_n_, "pig", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#ENTITIES}*/@Deprecated
++   public static final DefaultedRegistry<EntityType<?>> field_212629_r = forge(field_239713_n_, "pig", () -> {
        return EntityType.field_200784_X;
     });
 -   public static final DefaultedRegistry<Item> field_212630_s = func_239745_a_(field_239714_o_, "air", () -> {
-+   @Deprecated public static final DefaultedRegistry<Item> field_212630_s = forge(field_239714_o_, "air", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#ITEMS}*/@Deprecated
++   public static final DefaultedRegistry<Item> field_212630_s = forge(field_239714_o_, "air", () -> {
        return Items.field_190931_a;
     });
 -   public static final DefaultedRegistry<Potion> field_212621_j = func_239745_a_(field_239715_p_, "empty", () -> {
-+   @Deprecated public static final DefaultedRegistry<Potion> field_212621_j = forge(field_239715_p_, "empty", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#POTION_TYPES}*/@Deprecated
++   public static final DefaultedRegistry<Potion> field_212621_j = forge(field_239715_p_, "empty", () -> {
        return Potions.field_185229_a;
     });
 -   public static final Registry<ParticleType<?>> field_212632_u = func_239746_a_(field_239664_B_, () -> {
-+   @Deprecated public static final Registry<ParticleType<?>> field_212632_u = forge(field_239664_B_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#PARTICLE_TYPES}*/@Deprecated
++   public static final Registry<ParticleType<?>> field_212632_u = forge(field_239664_B_, () -> {
        return ParticleTypes.field_197611_d;
     });
 -   public static final Registry<TileEntityType<?>> field_212626_o = func_239746_a_(field_239667_E_, () -> {
-+   @Deprecated public static final Registry<TileEntityType<?>> field_212626_o = forge(field_239667_E_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#TILE_ENTITIES}*/@Deprecated
++   public static final Registry<TileEntityType<?>> field_212626_o = forge(field_239667_E_, () -> {
        return TileEntityType.field_200971_b;
     });
 -   public static final DefaultedRegistry<PaintingType> field_212620_i = func_239745_a_(field_239668_F_, "kebab", () -> {
-+   @Deprecated public static final DefaultedRegistry<PaintingType> field_212620_i = forge(field_239668_F_, "kebab", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#PAINTING_TYPES}*/@Deprecated
++   public static final DefaultedRegistry<PaintingType> field_212620_i = forge(field_239668_F_, "kebab", () -> {
        return PaintingType.field_200843_b;
     });
     public static final Registry<ResourceLocation> field_212623_l = func_239746_a_(field_239669_G_, () -> {
        return Stats.field_75953_u;
     });
 -   public static final DefaultedRegistry<ChunkStatus> field_218360_A = func_239745_a_(field_239670_H_, "empty", () -> {
-+   @Deprecated public static final DefaultedRegistry<ChunkStatus> field_218360_A = forge(field_239670_H_, "empty", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#CHUNK_STATUS}*/@Deprecated
++   public static final DefaultedRegistry<ChunkStatus> field_218360_A = forge(field_239670_H_, "empty", () -> {
        return ChunkStatus.field_223226_a_;
     });
     public static final Registry<IRuleTestType<?>> field_218363_D = func_239746_a_(field_239673_K_, () -> {
-@@ -178,40 +182,40 @@
+@@ -178,40 +194,50 @@
     public static final Registry<IPosRuleTests<?>> field_239691_aJ_ = func_239746_a_(field_239674_L_, () -> {
        return IPosRuleTests.field_237103_a_;
     });
 -   public static final Registry<ContainerType<?>> field_218366_G = func_239746_a_(field_239677_O_, () -> {
-+   @Deprecated public static final Registry<ContainerType<?>> field_218366_G = forge(field_239677_O_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#CONTAINERS}*/@Deprecated
++   public static final Registry<ContainerType<?>> field_218366_G = forge(field_239677_O_, () -> {
        return ContainerType.field_221514_h;
     });
     public static final Registry<IRecipeType<?>> field_218367_H = func_239746_a_(field_239678_P_, () -> {
        return IRecipeType.field_222149_a;
     });
 -   public static final Registry<IRecipeSerializer<?>> field_218368_I = func_239746_a_(field_239679_Q_, () -> {
-+   @Deprecated public static final Registry<IRecipeSerializer<?>> field_218368_I = forge(field_239679_Q_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#RECIPE_SERIALIZERS}*/@Deprecated
++   public static final Registry<IRecipeSerializer<?>> field_218368_I = forge(field_239679_Q_, () -> {
        return IRecipeSerializer.field_222158_b;
     });
 -   public static final Registry<Attribute> field_239692_aP_ = func_239746_a_(field_239680_R_, () -> {
-+   @Deprecated public static final Registry<Attribute> field_239692_aP_ = forge(field_239680_R_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#ATTRIBUTES}*/@Deprecated
++   public static final Registry<Attribute> field_239692_aP_ = forge(field_239680_R_, () -> {
        return Attributes.field_233828_k_;
     });
 -   public static final Registry<StatType<?>> field_212634_w = func_239746_a_(field_239681_S_, () -> {
-+   @Deprecated public static final Registry<StatType<?>> field_212634_w = forge(field_239681_S_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#STAT_TYPES}*/@Deprecated
++   public static final Registry<StatType<?>> field_212634_w = forge(field_239681_S_, () -> {
        return Stats.field_75929_E;
     });
     public static final DefaultedRegistry<VillagerType> field_218369_K = func_239745_a_(field_239682_T_, "plains", () -> {
        return VillagerType.field_221175_c;
     });
 -   public static final DefaultedRegistry<VillagerProfession> field_218370_L = func_239745_a_(field_239683_U_, "none", () -> {
-+   @Deprecated public static final DefaultedRegistry<VillagerProfession> field_218370_L = forge(field_239683_U_, "none", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#PROFESSIONS}*/@Deprecated
++   public static final DefaultedRegistry<VillagerProfession> field_218370_L = forge(field_239683_U_, "none", () -> {
        return VillagerProfession.field_221151_a;
     });
 -   public static final DefaultedRegistry<PointOfInterestType> field_218371_M = func_239745_a_(field_239684_V_, "unemployed", () -> {
-+   @Deprecated public static final DefaultedRegistry<PointOfInterestType> field_218371_M = forge(field_239684_V_, "unemployed", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#POI_TYPES}*/@Deprecated
++   public static final DefaultedRegistry<PointOfInterestType> field_218371_M = forge(field_239684_V_, "unemployed", () -> {
        return PointOfInterestType.field_221054_b;
     });
 -   public static final DefaultedRegistry<MemoryModuleType<?>> field_218372_N = func_239745_a_(field_239685_W_, "dummy", () -> {
-+   @Deprecated public static final DefaultedRegistry<MemoryModuleType<?>> field_218372_N = forge(field_239685_W_, "dummy", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#MEMORY_MODULE_TYPES}*/@Deprecated
++   public static final DefaultedRegistry<MemoryModuleType<?>> field_218372_N = forge(field_239685_W_, "dummy", () -> {
        return MemoryModuleType.field_220940_a;
     });
 -   public static final DefaultedRegistry<SensorType<?>> field_218373_O = func_239745_a_(field_239686_X_, "dummy", () -> {
-+   @Deprecated public static final DefaultedRegistry<SensorType<?>> field_218373_O = forge(field_239686_X_, "dummy", () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#SENSOR_TYPES}*/@Deprecated
++   public static final DefaultedRegistry<SensorType<?>> field_218373_O = forge(field_239686_X_, "dummy", () -> {
        return SensorType.field_220997_a;
     });
 -   public static final Registry<Schedule> field_218374_P = func_239746_a_(field_239687_Y_, () -> {
-+   @Deprecated public static final Registry<Schedule> field_218374_P = forge(field_239687_Y_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#SCHEDULES}*/@Deprecated
++   public static final Registry<Schedule> field_218374_P = forge(field_239687_Y_, () -> {
        return Schedule.field_221383_a;
     });
 -   public static final Registry<Activity> field_218375_Q = func_239746_a_(field_239688_Z_, () -> {
-+   @Deprecated public static final Registry<Activity> field_218375_Q = forge(field_239688_Z_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#ACTIVITIES}*/@Deprecated
++   public static final Registry<Activity> field_218375_Q = forge(field_239688_Z_, () -> {
        return Activity.field_221366_b;
     });
     public static final Registry<LootPoolEntryType> field_239693_aY_ = func_239746_a_(field_239695_aa_, () -> {
-@@ -232,19 +236,19 @@
+@@ -232,19 +258,23 @@
     public static final RegistryKey<Registry<JigsawPattern>> field_243555_ax = func_239741_a_("worldgen/template_pool");
     public static final RegistryKey<Registry<Biome>> field_239720_u_ = func_239741_a_("worldgen/biome");
     public static final RegistryKey<Registry<SurfaceBuilder<?>>> field_239717_r_ = func_239741_a_("worldgen/surface_builder");
 -   public static final Registry<SurfaceBuilder<?>> field_218378_p = func_239746_a_(field_239717_r_, () -> {
-+   @Deprecated public static final Registry<SurfaceBuilder<?>> field_218378_p = forge(field_239717_r_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#SURFACE_BUILDERS}*/@Deprecated
++   public static final Registry<SurfaceBuilder<?>> field_218378_p = forge(field_239717_r_, () -> {
        return SurfaceBuilder.field_215396_G;
     });
     public static final RegistryKey<Registry<WorldCarver<?>>> field_239716_q_ = func_239741_a_("worldgen/carver");
 -   public static final Registry<WorldCarver<?>> field_218377_o = func_239746_a_(field_239716_q_, () -> {
-+   @Deprecated public static final Registry<WorldCarver<?>> field_218377_o = forge(field_239716_q_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#WORLD_CARVERS}*/@Deprecated
++   public static final Registry<WorldCarver<?>> field_218377_o = forge(field_239716_q_, () -> {
        return WorldCarver.field_222709_a;
     });
     public static final RegistryKey<Registry<Feature<?>>> field_239718_s_ = func_239741_a_("worldgen/feature");
 -   public static final Registry<Feature<?>> field_218379_q = func_239746_a_(field_239718_s_, () -> {
-+   @Deprecated public static final Registry<Feature<?>> field_218379_q = forge(field_239718_s_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#FEATURES}*/@Deprecated
++   public static final Registry<Feature<?>> field_218379_q = forge(field_239718_s_, () -> {
        return Feature.field_202290_aj;
     });
     public static final RegistryKey<Registry<Structure<?>>> field_239671_I_ = func_239741_a_("worldgen/structure_feature");
 -   public static final Registry<Structure<?>> field_218361_B = func_239746_a_(field_239671_I_, () -> {
-+   @Deprecated public static final Registry<Structure<?>> field_218361_B = forge(field_239671_I_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#STRUCTURE_FEATURES}*/@Deprecated
++   public static final Registry<Structure<?>> field_218361_B = forge(field_239671_I_, () -> {
        return Structure.field_236367_c_;
     });
     public static final RegistryKey<Registry<IStructurePieceType>> field_239672_J_ = func_239741_a_("worldgen/structure_piece");
-@@ -252,7 +256,7 @@
+@@ -252,7 +282,8 @@
        return IStructurePieceType.field_214782_c;
     });
     public static final RegistryKey<Registry<Placement<?>>> field_239719_t_ = func_239741_a_("worldgen/decorator");
 -   public static final Registry<Placement<?>> field_218380_r = func_239746_a_(field_239719_t_, () -> {
-+   @Deprecated public static final Registry<Placement<?>> field_218380_r = forge(field_239719_t_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#DECORATORS}*/@Deprecated
++   public static final Registry<Placement<?>> field_218380_r = forge(field_239719_t_, () -> {
        return Placement.field_215022_h;
     });
     public static final RegistryKey<Registry<BlockStateProviderType<?>>> field_239721_v_ = func_239741_a_("worldgen/block_state_provider_type");
-@@ -265,19 +269,19 @@
+@@ -265,19 +296,23 @@
     public static final RegistryKey<Registry<Codec<? extends ChunkGenerator>>> field_239666_D_ = func_239741_a_("worldgen/chunk_generator");
     public static final RegistryKey<Registry<IStructureProcessorType<?>>> field_239675_M_ = func_239741_a_("worldgen/structure_processor");
     public static final RegistryKey<Registry<IJigsawDeserializer<?>>> field_239676_N_ = func_239741_a_("worldgen/structure_pool_element");
 -   public static final Registry<BlockStateProviderType<?>> field_229387_t_ = func_239746_a_(field_239721_v_, () -> {
-+   @Deprecated public static final Registry<BlockStateProviderType<?>> field_229387_t_ = forge(field_239721_v_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#BLOCK_STATE_PROVIDER_TYPES}*/@Deprecated
++   public static final Registry<BlockStateProviderType<?>> field_229387_t_ = forge(field_239721_v_, () -> {
        return BlockStateProviderType.field_227394_a_;
     });
 -   public static final Registry<BlockPlacerType<?>> field_229388_u_ = func_239746_a_(field_239722_w_, () -> {
-+   @Deprecated public static final Registry<BlockPlacerType<?>> field_229388_u_ = forge(field_239722_w_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#BLOCK_PLACER_TYPES}*/@Deprecated
++   public static final Registry<BlockPlacerType<?>> field_229388_u_ = forge(field_239722_w_, () -> {
        return BlockPlacerType.field_227259_a_;
     });
 -   public static final Registry<FoliagePlacerType<?>> field_229389_v_ = func_239746_a_(field_239723_x_, () -> {
-+   @Deprecated public static final Registry<FoliagePlacerType<?>> field_229389_v_ = forge(field_239723_x_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#FOLIAGE_PLACER_TYPES}*/@Deprecated
++   public static final Registry<FoliagePlacerType<?>> field_229389_v_ = forge(field_239723_x_, () -> {
        return FoliagePlacerType.field_227386_a_;
     });
     public static final Registry<TrunkPlacerType<?>> field_239701_aw_ = func_239746_a_(field_239724_y_, () -> {
        return TrunkPlacerType.field_236920_a_;
     });
 -   public static final Registry<TreeDecoratorType<?>> field_229390_w_ = func_239746_a_(field_239725_z_, () -> {
-+   @Deprecated public static final Registry<TreeDecoratorType<?>> field_229390_w_ = forge(field_239725_z_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#TREE_DECORATOR_TYPES}*/@Deprecated
++   public static final Registry<TreeDecoratorType<?>> field_229390_w_ = forge(field_239725_z_, () -> {
        return TreeDecoratorType.field_227426_b_;
     });
     public static final Registry<FeatureSizeType<?>> field_239702_ay_ = func_239746_a_(field_239663_A_, () -> {
-@@ -323,18 +327,34 @@
+@@ -323,18 +358,34 @@
        return func_239742_a_(p_239746_0_, Lifecycle.experimental(), p_239746_1_);
     }
  

--- a/patches/minecraft/net/minecraft/util/registry/WorldGenRegistries.java.patch
+++ b/patches/minecraft/net/minecraft/util/registry/WorldGenRegistries.java.patch
@@ -5,7 +5,7 @@
     });
     public static final Registry<JigsawPattern> field_243656_h = func_243667_a(Registry.field_243555_ax, JigsawPatternRegistry::func_244093_a);
 -   public static final Registry<Biome> field_243657_i = func_243667_a(Registry.field_239720_u_, () -> {
-+   @Deprecated public static final Registry<Biome> field_243657_i = forge(Registry.field_239720_u_, () -> {
++   /**@deprecated Use {@link net.minecraftforge.registries.ForgeRegistries#BIOMES}*/@Deprecated public static final Registry<Biome> field_243657_i = forge(Registry.field_239720_u_, () -> {
        return BiomeRegistry.field_244200_a;
     });
     public static final Registry<DimensionSettings> field_243658_j = func_243667_a(Registry.field_243549_ar, DimensionSettings::func_242746_i);

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -206,7 +206,7 @@
 +   /**
 +    * <strong>FOR INTERNAL USE ONLY</strong>
 +    * <p>
-+    * Only public for use in {@link AnvilChunkLoader}.
++    * Only public for use in {@link net.minecraft.world.chunk.storage.ChunkSerializer}.
 +    */
 +   @java.lang.Deprecated
 +   @javax.annotation.Nullable
@@ -217,7 +217,7 @@
 +   /**
 +    * <strong>FOR INTERNAL USE ONLY</strong>
 +    * <p>
-+    * Only public for use in {@link AnvilChunkLoader}.
++    * Only public for use in {@link net.minecraft.world.chunk.storage.ChunkSerializer}.
 +    */
 +   @java.lang.Deprecated
 +   public final void readCapsFromNBT(CompoundNBT tag) {

--- a/patches/minecraft/net/minecraft/world/gen/feature/template/StructureProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/template/StructureProcessor.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/world/gen/feature/template/StructureProcessor.java
 +++ b/net/minecraft/world/gen/feature/template/StructureProcessor.java
-@@ -6,7 +6,37 @@
+@@ -5,8 +5,38 @@
+ import net.minecraft.world.IWorldReader;
  
  public abstract class StructureProcessor {
++   /**@deprecated Use {@link StructureProcessor#process(IWorldReader, BlockPos, BlockPos, Template.BlockInfo, Template.BlockInfo, PlacementSettings, Template)}*/@Deprecated
     @Nullable
 -   public abstract Template.BlockInfo func_230386_a_(IWorldReader p_230386_1_, BlockPos p_230386_2_, BlockPos p_230386_3_, Template.BlockInfo p_230386_4_, Template.BlockInfo p_230386_5_, PlacementSettings p_230386_6_);
-+   @Deprecated // Forge: Use process below, with the Template context
 +   public Template.BlockInfo func_230386_a_(IWorldReader p_230386_1_, BlockPos p_230386_2_, BlockPos p_230386_3_, Template.BlockInfo p_230386_4_, Template.BlockInfo p_230386_5_, PlacementSettings p_230386_6_) {
 +      return p_230386_5_;
 +   }

--- a/patches/minecraft/net/minecraft/world/gen/feature/template/Template.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/template/Template.java.patch
@@ -33,7 +33,7 @@
        });
     }
  
-+   @Deprecated // Forge: Use Forge version
++   /**@deprecated Use {@link Template#processBlockInfos(IWorld, BlockPos, BlockPos, PlacementSettings, List, Template)}*/@Deprecated
     public static List<Template.BlockInfo> func_237145_a_(IWorld p_237145_0_, BlockPos p_237145_1_, BlockPos p_237145_2_, PlacementSettings p_237145_3_, List<Template.BlockInfo> p_237145_4_) {
 +      return processBlockInfos(p_237145_0_, p_237145_1_, p_237145_2_, p_237145_3_, p_237145_4_, null);
 +   }

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -126,7 +126,7 @@
  
     }
  
-+   @Deprecated // Forge: Use removeEntityComplete(entity,boolean)
++   /**@deprecated Use {@link ServerWorld#removeEntityComplete(Entity, boolean)}*/@Deprecated
     public void func_217484_g(Entity p_217484_1_) {
 +      removeEntityComplete(p_217484_1_, false);
 +   }


### PR DESCRIPTION
Copy of MinecraftForge/MinecraftForge#7478

Improves the Javadoc documentation for most of the forge patches that mark vanilla fields/methods/classes/etc. as `@Deprecated`, providing a link to the replacement field/method/class/etc. if applicable, or a description of why that field/method/class/etc. should not be used, or whatever relevant information is needed to explain the deprecation..

If you have suggestions for further improvements, please let me know. There are a few `@Deprecated` things that I wasn't able to add documentation for because I wasn't sure what to say.