### PR TITLE
Deprecate GameRegistry for removal in 1.17

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -24,6 +24,10 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
 
 
+/**
+ * @deprecated To be removed in 1.17
+ */
+@Deprecated
 public class GameRegistry
 {
     /**
@@ -33,7 +37,9 @@ public class GameRegistry
      *
      * @param registryType The base class of items in this registry.
      * @return The registry, Null if none is registered.
+     * @deprecated To be removed in 1.17, see {@link RegistryManager#ACTIVE}{@code .}{@link RegistryManager#getRegistry(Class)}
      */
+    @Deprecated
     public static <K extends IForgeRegistryEntry<K>> IForgeRegistry<K> findRegistry(Class<K> registryType)
     {
         return RegistryManager.ACTIVE.getRegistry(registryType);


### PR DESCRIPTION
This PR deprecates `GameRegistry` and its method, `GameRegistry#findRegistry`, for removal in 1.17.

This class has existed since before the Forge 1.13 rewrite, and was heavily gutted as a result of that rewrite. It's sole remaininghas been effectively superseded by `RegistryManager.ACTIVE#getRegistry`, so this class does not need to exist now.

For the sake of people who _somehow_ still use this class, it will only be deprecated for now, but will be removed in 1.17 (either a PR by me, or someone in Forge doing the removal themselves).