### PR TITLE
Update IItemHandler#insertItem documentation

### DIFF
--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -64,10 +64,11 @@ public interface IItemHandler
      * Inserts an ItemStack into the given slot and return the remainder.
      * The ItemStack <em>should not</em> be modified in this function!
      * </p>
-     * Note: This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, boolean)}
+     * Note: This function returns the REMAINDER - what was NOT inserted!
+     * This behaviour is subtly different from {@link IFluidHandler#fill}, which returns what was inserted.
      *
      * @param slot     Slot to insert into.
-     * @param stack    ItemStack to insert. This must not be modified by the item handler.
+     * @param stack    ItemStack to insert. Its ownership is given to the item handler. It must never be used or modified by the caller afterwards!
      * @param simulate If true, the insertion is only simulated
      * @return The remaining ItemStack that was not inserted (if the entire stack is accepted, then return an empty ItemStack).
      *         May be the same as the input ItemStack if unchanged, otherwise a new ItemStack.


### PR DESCRIPTION
Explain that the handler receives ownership of the inserted stack. (Relevant discussion on ForgeCord: https://discord.com/channels/313125603924639766/725850371834118214/846696683148017684)

I also explained how exactly this behavior is subtly different from `IFluidHandler#fill` (now taking `FluidAction` instead of `boolean`, so I decided to drop the explicit params).